### PR TITLE
Minor db-related fixes

### DIFF
--- a/src/db/util/init.ts
+++ b/src/db/util/init.ts
@@ -26,14 +26,27 @@ export async function init(rpcUrl: string, isRemote = false): Promise<[DB, UserD
 }
 
 export async function initDb(rpcUrl: string): Promise<DB> {
-  const db = await new DB(
-    rpcUrl,
-    { name: 'User', schema: user },
-    { name: 'Contract', schema: contract },
-    { name: 'CodeBundle', schema: codeBundle }
-  ).open(2);
+  let db: DB;
+  let version = 1;
+  let isReady = false;
 
-  return db;
+  while (!isReady && version <= 999) {
+    try {
+      db = await new DB(
+        rpcUrl,
+        { name: 'User', schema: user },
+        { name: 'Contract', schema: contract },
+        { name: 'CodeBundle', schema: codeBundle }
+      ).open(version);
+    
+      isReady = true;
+      return db;
+    } catch (e) {
+      version += 1;
+    }
+  }
+
+  throw new Error('Unable to initialize database');
 }
 
 export async function initIdentity (db: DB): Promise<[UserDocument | null, PrivateKey]> {

--- a/src/ui/hooks/useQuery.ts
+++ b/src/ui/hooks/useQuery.ts
@@ -17,22 +17,25 @@ export function useQuery<T>(query: () => Promise<T | null>): UseQuery<T> {
     query()
       .then(result => {
         setData(result);
-        setData(result);
         setIsLoading(false);
         setIsValid(!!result);
         setUpdated(Date.now());
       })
-      .catch(e => console.error(e));
+      .catch(e => {
+        setIsValid(false);
+        console.error(e);
+      });
   }, [isDbReady, query]);
 
   const refresh = useCallback((): void => {
     setIsLoading(true);
+    setIsValid(true);
     fetch();
   }, [fetch]);
 
   useEffect((): void => {
     fetch();
-  });
+  }, []);
 
   return { data, isLoading, isValid, refresh, updated };
 }


### PR DESCRIPTION
- Fix ```useQuery``` to fetch on initial render instead of infinitely, set ```isValid``` correctly
- Fix ```initDb``` to iterate through versions until correct one is found - was causing a problem when reviewing PRs with earlier versions. Eventually will be better to do this in combination with a version number in localStorage.