### PR TITLE
Run lint-staged on all files

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,6 @@
   ],
   "lint-staged": {
     "*.{js,cjs,ts,tsx}": "eslint --cache --fix",
-    "*.{js,cjs,ts,tsx,css,md}": "prettier --write"
+    "*.{js,cjs,ts,tsx,css,md,json}": "prettier --write"
   }
 }


### PR DESCRIPTION
auto formatting staged files was running only on `.js` files