### PR TITLE
Fix call message of previous contract

### DIFF
--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -35,6 +35,7 @@ export const InteractTab = ({ contract }: Props) => {
         type: 'RESET',
       });
     }
+    message.value = contract.abi.messages[0];
   }, [contract.address]);
 
   if (!contract) return null;


### PR DESCRIPTION
when navigating to another contract, the state was not properly re-initialised so the previous contract's message was being called