### PR TITLE
Show better formatted BN in call results

### DIFF
--- a/src/types/ui/contract.ts
+++ b/src/types/ui/contract.ts
@@ -5,6 +5,7 @@ import BN from 'bn.js';
 import type {
   AbiMessage,
   AnyJson,
+  Codec,
   ContractPromise,
   KeyringPair,
   RegistryError,
@@ -19,7 +20,7 @@ export interface ContractDryRunParams {
 }
 
 export interface CallResult {
-  data: AnyJson;
+  data: Codec | null;
   id: number;
   isComplete: boolean;
   log: string[];

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -91,7 +91,7 @@ export const InteractTab = ({ contract }: Props) => {
       ...callResults,
       {
         id: nextResultId,
-        data: '',
+        data: null,
         isComplete: true,
         message,
         time: Date.now(),
@@ -127,7 +127,7 @@ export const InteractTab = ({ contract }: Props) => {
         message,
         time: Date.now(),
         isComplete: true,
-        data: output?.toHuman(),
+        data: output,
         error,
       },
     ]);

--- a/src/ui/components/contract/QueryResult.tsx
+++ b/src/ui/components/contract/QueryResult.tsx
@@ -4,14 +4,19 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { isBn } from '@polkadot/util';
 import { MessageSignature } from '../message/MessageSignature';
 import { CallResult } from 'types';
+import { useApi } from 'ui/contexts';
+import { fromSats } from 'api';
 
 interface Props {
   result: CallResult;
   date: string;
 }
 export const QueryResult = ({ result: { time, data, message, error }, date }: Props) => {
+  const { api } = useApi();
+
   return (
     <div
       key={`${time}`}
@@ -22,7 +27,9 @@ export const QueryResult = ({ result: { time, data, message, error }, date }: Pr
         <div className="mb-2">
           <MessageSignature message={message} />
         </div>
-        <div className="bg-elevation-1 p-2 rounded-sm text-mono">{`${data}`}</div>
+        <div className="bg-elevation-1 p-2 rounded-sm text-mono">{`${
+          isBn(data) ? fromSats(api, data) : data
+        }`}</div>
       </div>
       {error && (
         <ReactMarkdown

--- a/src/ui/components/form/InputBalance.tsx
+++ b/src/ui/components/form/InputBalance.tsx
@@ -43,7 +43,8 @@ function InputBalanceBase({ children, value = BN_ZERO, onChange: _onChange }: Pr
           value={stringValue}
         >
           <div className="absolute inset-y-0 right-0 flex items-center">
-            <label htmlFor="unit" className="sr-only">
+            <span className="text-gray-500 sm:text-sm mr-7">{tokenSymbol}</span>
+            {/* <label htmlFor="unit" className="sr-only">
               Unit
             </label>
             <select
@@ -53,7 +54,7 @@ function InputBalanceBase({ children, value = BN_ZERO, onChange: _onChange }: Pr
               className="focus:ring-indigo-500 focus:border-indigo-500 h-full py-0 pl-2 pr-7 border-transparent bg-transparent text-gray-500 sm:text-sm rounded-md"
             >
               <option value={tokenSymbol}>{tokenSymbol}</option>
-            </select>
+            </select> */}
           </div>
           {children}
         </Input>


### PR DESCRIPTION
Consistent BN formatting for inputs and results output 
Hide the units dropdown in `InputBalance` as it's not yet functional

For user input `1234` you got back `1,234,000,000,000,000` in the results output panel. This PR fixes that.
