### PR TITLE
Error forwarding

### DIFF
--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -62,7 +62,11 @@ export const InteractTab = ({ contract }: Props) => {
         payment: value,
         sender,
       })
-        .then(({ gasRequired }) => {
+        .then(({ result, gasRequired }) => {
+          if (result.isOk) {
+            const { flags } = result.asOk;
+            console.log(`flags: ${flags.toNumber()}`);
+          }
           setEstimatedWeight(gasRequired);
         })
         .catch(e => {

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -67,7 +67,9 @@ export const InteractTab = ({ contract }: Props) => {
         .then(({ result, gasRequired }) => {
           if (result.isOk) {
             const { flags } = result.asOk;
-            if (flags.toNumber() === 1) throw new Error('RPC dry-run call reverted');
+            if (flags.toNumber() === 1) {
+              throw new Error('RPC dry-run call reverted');
+            }
           }
           setEstimatedWeight(gasRequired);
           setRpcDryRunResult('success');
@@ -220,10 +222,7 @@ export const InteractTab = ({ contract }: Props) => {
         <Buttons>
           {message.isPayable || message.isMutating ? (
             <Button
-              isDisabled={
-                !(weight.isValid || weight.isEmpty || txs[txId]?.status === 'processing') ||
-                rpcDryRunResult !== 'success'
-              }
+              isDisabled={!(weight.isValid || weight.isEmpty || txs[txId]?.status === 'processing')}
               isLoading={txs[txId]?.status === 'processing'}
               onClick={() => clickHandler()}
               variant="primary"


### PR DESCRIPTION
Closes #133 

Implements the following:

- reads the `flags` from RPC dry-run result, throws an error if revert bit is set
- displays RPC dry-run results in UI
- ~~disables Call button if RPC dry-run was not successfull~~

As discussed with @statictype , we don't disable the Call button when the dry-run was not successfull.