### PR TITLE
Mono font adjustments

### DIFF
--- a/src/ui/components/message/MessageDocs.tsx
+++ b/src/ui/components/message/MessageDocs.tsx
@@ -18,7 +18,7 @@ export const MessageDocs = ({ message, message: { docs } }: Props) => {
     <Disclosure defaultOpen>
       {({ open }) => (
         <div className="collapsible-panel">
-          <Disclosure.Button className="panel-title text-xs leading-normal p-3 dark:bg-elevation-1 text-mono flex w-full">
+          <Disclosure.Button className="panel-title text-xs leading-normal text-left p-3 dark:bg-elevation-1 text-mono flex w-full">
             <ChevronUpIcon
               className={`${open ? 'transform rotate-180' : ''} w-5 h-5 mr-1 border-gray-500`}
             />

--- a/src/ui/styles/dropdown.css
+++ b/src/ui/styles/dropdown.css
@@ -84,3 +84,9 @@
 .account-select .dropdown__control {
   min-height: 68px;
 }
+
+.dropdown .dropdown__control .font-mono,
+.dropdown .dropdown__menu .font-mono,
+.dropdown.chain .dropdown__single-value .font-mono {
+  @apply text-xs;
+}

--- a/src/ui/styles/form.css
+++ b/src/ui/styles/form.css
@@ -6,6 +6,10 @@
   @apply block mb-1.5 text-sm font-semibold dark:text-white;
 }
 
+.form-field > label .font-mono {
+  @apply text-xs;
+}
+
 .form-field > .validation {
   @apply mt-2 text-sm flex items-center;
 }


### PR DESCRIPTION
Making sure mono font is always 12px in dropdowns as SF mono renders bigger than SF Display. And left-align headers in the metadata section.
Before:
<img width="658" alt="Screenshot 2022-03-10 at 15 29 23" src="https://user-images.githubusercontent.com/7072141/157696578-87426f2e-d104-46ad-8276-465527b64a73.png">
Now:
<img width="641" alt="Screenshot 2022-03-10 at 15 42 02" src="https://user-images.githubusercontent.com/7072141/157696594-1ec344c2-a0c3-4cf4-aa53-ffb63697a208.png">