### PR TITLE
Remove license from every file

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,13 +17,7 @@
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "prettier"
   ],
-  "plugins": [
-    "header",
-    "import",
-    "@typescript-eslint",
-    "eslint-plugin-react",
-    "eslint-plugin-react-hooks"
-  ],
+  "plugins": ["import", "@typescript-eslint", "eslint-plugin-react", "eslint-plugin-react-hooks"],
   "overrides": [
     {
       "files": ["*.tsx", "*.js", "*.jsx", "*.ts"],
@@ -48,18 +42,6 @@
     }
   },
   "rules": {
-    "header/header": [
-      2,
-      "line",
-      [
-        {
-          "pattern": " Copyright \\d{4}(-\\d{4})? @paritytech/contracts-ui authors & contributors",
-          "template": " Copyright 2021 @paritytech/contracts-ui authors & contributors"
-        },
-        " SPDX-License-Identifier: Apache-2.0"
-      ],
-      2
-    ],
     "indent": "off",
     "import/named": "off",
     "import/no-unresolved": "error",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "eslint": "^8.9.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-import-resolver-typescript": "^2.5.0",
-    "eslint-plugin-header": "^3.1.1",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",

--- a/src/api/chainProps.ts
+++ b/src/api/chainProps.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { TypeRegistry } from '@polkadot/types/create';
 import { DEFAULT_DECIMALS } from '../constants';
 import { blockTimeMs } from 'api/util/blockTime';

--- a/src/api/connect.ts
+++ b/src/api/connect.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { isValidWsUrl } from './util';
 import { getChainPropertiesWhenReady } from './chainProps';

--- a/src/api/contract/call.ts
+++ b/src/api/contract/call.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { transformUserInput } from 'api/util';
 
 import {

--- a/src/api/contract/index.ts
+++ b/src/api/contract/index.ts
@@ -1,4 +1,1 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './call';

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './instantiate';
 export * from './util';
 export * from './contract';

--- a/src/api/instantiate/createInstantiateTx.ts
+++ b/src/api/instantiate/createInstantiateTx.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { BlueprintPromise, CodePromise } from '@polkadot/api-contract';
 import { isNumber } from '@polkadot/util';
 import { encodeSalt, transformUserInput } from '../util';

--- a/src/api/instantiate/index.ts
+++ b/src/api/instantiate/index.ts
@@ -1,5 +1,2 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './instantiate';
 export * from './createInstantiateTx';

--- a/src/api/instantiate/instantiate.ts
+++ b/src/api/instantiate/instantiate.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type {
   ApiState,
   DbState,

--- a/src/api/loadAccounts.ts
+++ b/src/api/loadAccounts.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { web3Accounts, web3Enable } from '@polkadot/extension-dapp';
 import { keyring as Keyring } from '@polkadot/ui-keyring';
 import { isTestChain } from '@polkadot/util';

--- a/src/api/util/blockTime.ts
+++ b/src/api/util/blockTime.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { BN_THOUSAND, BN_TWO, BN } from '@polkadot/util';
 import { ApiPromise, OrFalsy } from 'types';
 

--- a/src/api/util/index.ts
+++ b/src/api/util/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import BN from 'bn.js';
 import { compactAddLength, u8aToU8a, isNumber, BN_TEN } from '@polkadot/util';
 import { randomAsU8a } from '@polkadot/util-crypto';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import BN from 'bn.js';
 import type { ApiState } from 'types';
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './queries';
 export * from './schemas';
 export * from './util';

--- a/src/db/queries/codeBundle.ts
+++ b/src/db/queries/codeBundle.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Database, PrivateKey } from '@textile/threaddb';
 import { getNewCodeBundleId, publicKeyHex } from '../util';
 import { findUser } from './user';

--- a/src/db/queries/contract.ts
+++ b/src/db/queries/contract.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Database, PrivateKey } from '@textile/threaddb';
 import { keyring } from '@polkadot/ui-keyring';
 import { publicKeyHex } from '../util';

--- a/src/db/queries/derive.ts
+++ b/src/db/queries/derive.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { getCodeBundleCollection, getContractCollection } from './util';
 // import { findTopCodeBundles } from "./codeBundle";
 import type { Database, DbStatistics } from 'types';

--- a/src/db/queries/index.ts
+++ b/src/db/queries/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './codeBundle';
 export * from './contract';
 export * from './derive';

--- a/src/db/queries/user.ts
+++ b/src/db/queries/user.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Database, PrivateKey } from '@textile/threaddb';
 
 import { publicKeyHex } from '../util/identity';

--- a/src/db/queries/util.ts
+++ b/src/db/queries/util.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Collection, Database } from '@textile/threaddb';
 import type { CodeBundleDocument, ContractDocument, UserDocument } from 'types';
 

--- a/src/db/schemas/index.ts
+++ b/src/db/schemas/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { JSONSchema4 } from 'json-schema';
 
 import codeBundleSchema from './codeBundle.schema.json';

--- a/src/db/util/codeBundle.ts
+++ b/src/db/util/codeBundle.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { nanoid } from 'nanoid';
 
 export function getNewCodeBundleId(): string {

--- a/src/db/util/identity.ts
+++ b/src/db/util/identity.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { keccakAsU8a } from '@polkadot/util-crypto';
 import { PrivateKey } from '@textile/crypto';
 import bcrypt from 'bcryptjs';

--- a/src/db/util/index.ts
+++ b/src/db/util/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './codeBundle';
 export * from './identity';
 export * from './init';

--- a/src/db/util/init.ts
+++ b/src/db/util/init.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { PrivateKey } from '@textile/crypto';
 import { ThreadID } from '@textile/threads-id';
 import { Database as DB } from '@textile/threaddb';

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import type { Collection, Database } from '@textile/threaddb';
 import type { PrivateKey } from '@textile/crypto';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './db';
 export * from './substrate';
 export * from './ui';

--- a/src/types/substrate.ts
+++ b/src/types/substrate.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 // types & interfaces
 export type { AnyJson, Codec, Registry, RegistryError, TypeDef } from '@polkadot/types/types';
 export type { DispatchError, EventRecord, Weight, ChainType } from '@polkadot/types/interfaces';

--- a/src/types/ui/components.ts
+++ b/src/types/ui/components.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Props as ReactSelectProps } from 'react-select';
 import { ValidFormField } from './hooks';
@@ -14,7 +11,7 @@ export interface DropdownOption<T> {
 export type ArgComponentProps<T> = SimpleSpread<
   React.HTMLAttributes<HTMLDivElement>,
   ValidFormField<T>
->
+>;
 
 export type DropdownProps<T> = SimpleSpread<
   React.HTMLAttributes<HTMLDivElement>,

--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type {
   Abi,
   ApiPromise,

--- a/src/types/ui/contract.ts
+++ b/src/types/ui/contract.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import BN from 'bn.js';
 import type {
   AbiMessage,

--- a/src/types/ui/hooks.ts
+++ b/src/types/ui/hooks.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { VoidFn } from '../substrate';
 import { BN, FileState, MetadataState, OrFalsy, SetState, Validation } from './util';
 

--- a/src/types/ui/index.ts
+++ b/src/types/ui/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './components';
 export * from './contexts';
 export * from './contract';

--- a/src/types/ui/util.ts
+++ b/src/types/ui/util.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import BN from 'bn.js';
 import type { Abi } from '../substrate';
 

--- a/src/ui/components/App.tsx
+++ b/src/ui/components/App.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Outlet } from 'react-router';
 import { Sidebar, AwaitApis } from 'ui/components';

--- a/src/ui/components/AwaitApis.tsx
+++ b/src/ui/components/AwaitApis.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useMemo } from 'react';
 import type { HTMLAttributes } from 'react';
 import { Loader } from './common/Loader';

--- a/src/ui/components/Transactions.tsx
+++ b/src/ui/components/Transactions.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { BellIcon, XIcon } from '@heroicons/react/outline';
 import React from 'react';
 import { NotificationIcon } from './common/NotificationIcon';

--- a/src/ui/components/account/Account.tsx
+++ b/src/ui/components/account/Account.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Identicon } from './Identicon';
 import { classes, truncate } from 'ui/util';

--- a/src/ui/components/account/Identicon.tsx
+++ b/src/ui/components/account/Identicon.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Circle } from '@polkadot/ui-shared/icons/types';
 
 import React from 'react';

--- a/src/ui/components/account/Select.tsx
+++ b/src/ui/components/account/Select.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useMemo } from 'react';
 import { GroupBase } from 'react-select';
 import { Dropdown } from '../common/Dropdown';

--- a/src/ui/components/account/index.ts
+++ b/src/ui/components/account/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './Account';
 export * from './Select';
 export * from './Identicon';

--- a/src/ui/components/common/Button.tsx
+++ b/src/ui/components/common/Button.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { classes } from 'ui/util';
 

--- a/src/ui/components/common/Dropdown.tsx
+++ b/src/ui/components/common/Dropdown.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useMemo } from 'react';
 import Select, {
   components,

--- a/src/ui/components/common/HeaderButtons.tsx
+++ b/src/ui/components/common/HeaderButtons.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { ArrowCircleRightIcon } from '@heroicons/react/outline';
 import { Link } from 'react-router-dom';

--- a/src/ui/components/common/Loader.tsx
+++ b/src/ui/components/common/Loader.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Spinner } from './Spinner';
 

--- a/src/ui/components/common/NotificationIcon.tsx
+++ b/src/ui/components/common/NotificationIcon.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { CheckIcon, ClockIcon, ExclamationCircleIcon } from '@heroicons/react/outline';
 import React from 'react';
 import { Spinner } from './Spinner';

--- a/src/ui/components/common/SearchResults.tsx
+++ b/src/ui/components/common/SearchResults.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { CodeIcon } from '@heroicons/react/outline';
 import React from 'react';
 import { CodeBundleDocument, ContractDocument, VoidFn } from 'types';

--- a/src/ui/components/common/Spinner.tsx
+++ b/src/ui/components/common/Spinner.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { classes } from 'ui/util';
 

--- a/src/ui/components/common/Switch.tsx
+++ b/src/ui/components/common/Switch.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { HTMLAttributes } from 'react';
 import { Switch as HUISwitch } from '@headlessui/react';
 import { classes } from 'ui/util';

--- a/src/ui/components/common/Tabs.tsx
+++ b/src/ui/components/common/Tabs.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import type { SetState } from 'types';
 import { classes } from 'ui/util';

--- a/src/ui/components/common/index.ts
+++ b/src/ui/components/common/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './Button';
 export * from './Dropdown';
 export * from './HeaderButtons';

--- a/src/ui/components/contract/ContractRow.tsx
+++ b/src/ui/components/contract/ContractRow.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import 'styled-components';
 import { Link } from 'react-router-dom';

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect, useState, useRef } from 'react';
 import { BN_ZERO } from '@polkadot/util';
 import { ResultsOutput } from './ResultsOutput';

--- a/src/ui/components/contract/Metadata.tsx
+++ b/src/ui/components/contract/Metadata.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { MessageDocs } from '../message/MessageDocs';
 import { Abi } from 'types';

--- a/src/ui/components/contract/QueryResult.tsx
+++ b/src/ui/components/contract/QueryResult.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/src/ui/components/contract/ResultsOutput.tsx
+++ b/src/ui/components/contract/ResultsOutput.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { QueryResult } from './QueryResult';
 import { TransactionResult } from './TransactionResult';

--- a/src/ui/components/contract/TransactionResult.tsx
+++ b/src/ui/components/contract/TransactionResult.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/src/ui/components/contract/index.ts
+++ b/src/ui/components/contract/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './ContractRow';
 export * from './Interact';
 export * from './Metadata';

--- a/src/ui/components/form/ArgumentForm.tsx
+++ b/src/ui/components/form/ArgumentForm.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { ArgSignature } from '../message/ArgSignature';
 import { Form, FormField } from './FormField';

--- a/src/ui/components/form/Bool.tsx
+++ b/src/ui/components/form/Bool.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { SimpleSpread, ValidFormField } from 'types';
 import { Dropdown } from 'ui/components/common/Dropdown';

--- a/src/ui/components/form/CodeHashField.tsx
+++ b/src/ui/components/form/CodeHashField.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { CodeHash } from '../instantiate/CodeHash';
 import { FormField } from './FormField';

--- a/src/ui/components/form/ContractNameField.tsx
+++ b/src/ui/components/form/ContractNameField.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { FormField } from './FormField';
 import { Input } from './Input';

--- a/src/ui/components/form/Enum.tsx
+++ b/src/ui/components/form/Enum.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useState } from 'react';
 import { isNumber } from '@polkadot/util';
 import { Dropdown } from '../common/Dropdown';
@@ -14,22 +11,27 @@ type Props = SimpleSpread<
   React.InputHTMLAttributes<HTMLInputElement>,
   ValidFormField<Record<string, unknown>>
 > & {
-  components: React.ComponentType<ValidFormField<unknown>>[],
-  registry: Registry,
-  typeDef: TypeDef
+  components: React.ComponentType<ValidFormField<unknown>>[];
+  registry: Registry;
+  typeDef: TypeDef;
 };
 
-export function Enum (props: Props) {
+export function Enum(props: Props) {
   const { components, typeDef, onChange: _onChange, registry, value = {} } = props;
   const variants = typeDef.sub as TypeDef[];
   const { keyring } = useApi();
-  const [variantIndex, _setVariantIndex] = useState<number>(Math.max(0, variants.findIndex(({ name }) => name === Object.keys(value)[0])));
-  
+  const [variantIndex, _setVariantIndex] = useState<number>(
+    Math.max(
+      0,
+      variants.findIndex(({ name }) => name === Object.keys(value)[0])
+    )
+  );
+
   const Component = components[variantIndex];
 
   const onChange = useCallback(
     (value: unknown): void => {
-      _onChange({ [variants[variantIndex].name as string]: value })
+      _onChange({ [variants[variantIndex].name as string]: value });
     },
     [_onChange, variants, variantIndex]
   );
@@ -39,11 +41,13 @@ export function Enum (props: Props) {
       if (isNumber(value)) {
         _setVariantIndex(value);
 
-        _onChange({ [variants[value].name as string]: getInitValue(registry, keyring, variants[value])})
+        _onChange({
+          [variants[value].name as string]: getInitValue(registry, keyring, variants[value]),
+        });
       }
     },
     [registry, keyring, _onChange, variants]
-  )
+  );
 
   return (
     <>
@@ -55,15 +59,10 @@ export function Enum (props: Props) {
       {variants[variantIndex].type !== 'Null' && (
         <FormField
           className="ml-8 mt-2"
-          label={
-            <ArgSignature arg={{ type: variants[variantIndex] }} />
-          }
+          label={<ArgSignature arg={{ type: variants[variantIndex] }} />}
           {...getValidation(props)}
         >
-          <Component
-            value={Object.values(value)[0]}
-            onChange={onChange}
-          />
+          <Component value={Object.values(value)[0]} onChange={onChange} />
         </FormField>
       )}
     </>

--- a/src/ui/components/form/FormField.tsx
+++ b/src/ui/components/form/FormField.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/outline';
 import React, { useMemo } from 'react';
 import type { Validation } from 'types';

--- a/src/ui/components/form/Input.tsx
+++ b/src/ui/components/form/Input.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { SimpleSpread } from 'types';
 import { classes } from 'ui/util';

--- a/src/ui/components/form/InputBalance.tsx
+++ b/src/ui/components/form/InputBalance.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useState } from 'react';
 import BN from 'bn.js';
 import { BN_ZERO } from '@polkadot/util';

--- a/src/ui/components/form/InputFile.tsx
+++ b/src/ui/components/form/InputFile.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable header/header */
 // Copyright 2021 @paritytech/contracts-ui authors & contributors
 // Copyright 2017-2021 @polkadot/react-components authors & contributors
 // SPDX-License-Identifier: Apache-2.0

--- a/src/ui/components/form/InputGas.tsx
+++ b/src/ui/components/form/InputGas.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect } from 'react';
 import { BN_MILLION, BN_ZERO } from '@polkadot/util';
 import { InputNumber } from './InputNumber';

--- a/src/ui/components/form/InputNumber.tsx
+++ b/src/ui/components/form/InputNumber.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import BN from 'bn.js';
 import React, { useCallback } from 'react';
 import { BN_ZERO } from '@polkadot/util';

--- a/src/ui/components/form/InputSalt.tsx
+++ b/src/ui/components/form/InputSalt.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Switch } from '../common/Switch';
 import { Input } from './Input';

--- a/src/ui/components/form/Vector.tsx
+++ b/src/ui/components/form/Vector.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { TypeDef } from '@polkadot/types/types';
 import React from 'react';
 import { Button, Buttons } from '../common';

--- a/src/ui/components/form/findComponent.tsx
+++ b/src/ui/components/form/findComponent.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { AddressSelect } from '../account/Select';
 import { Input } from './Input';

--- a/src/ui/components/form/hooks/useAccountField.tsx
+++ b/src/ui/components/form/hooks/useAccountField.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 
 import { AccountSelect } from '../../account/Select';

--- a/src/ui/components/form/hooks/useMetadataField.tsx
+++ b/src/ui/components/form/hooks/useMetadataField.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useState, useMemo, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { FormField, getValidation } from '../FormField';

--- a/src/ui/components/form/index.ts
+++ b/src/ui/components/form/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './FormField';
 export * from './Input';
 export * from './InputBalance';

--- a/src/ui/components/homepage/Contracts.tsx
+++ b/src/ui/components/homepage/Contracts.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback } from 'react';
 import { FolderOpenIcon } from '@heroicons/react/outline';
 import { Link } from 'react-router-dom';

--- a/src/ui/components/homepage/HelpBox.tsx
+++ b/src/ui/components/homepage/HelpBox.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback } from 'react';
 import { XIcon } from '@heroicons/react/outline';
 import { Button } from '../common/Button';

--- a/src/ui/components/homepage/Statistics.tsx
+++ b/src/ui/components/homepage/Statistics.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { formatNumber } from '@polkadot/util';
 import { StarIcon as StarIconOutline } from '@heroicons/react/outline';

--- a/src/ui/components/homepage/index.ts
+++ b/src/ui/components/homepage/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './Contracts';
 export * from './HelpBox';
 export * from './Statistics';

--- a/src/ui/components/index.ts
+++ b/src/ui/components/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './account';
 export * from './common';
 export * from './contract';

--- a/src/ui/components/instantiate/AvailableCodeBundles.tsx
+++ b/src/ui/components/instantiate/AvailableCodeBundles.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { FormField } from '../form/FormField';

--- a/src/ui/components/instantiate/CodeHash.tsx
+++ b/src/ui/components/instantiate/CodeHash.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { ChevronRightIcon } from '@heroicons/react/outline';
 import React from 'react';
 import { SimpleSpread, VoidFn } from 'types';

--- a/src/ui/components/instantiate/LookUpCodeHash.tsx
+++ b/src/ui/components/instantiate/LookUpCodeHash.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { XCircleIcon } from '@heroicons/react/outline';

--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect } from 'react';
 import { useParams } from 'react-router';
 import { Button, Buttons } from '../common/Button';

--- a/src/ui/components/instantiate/Step2.tsx
+++ b/src/ui/components/instantiate/Step2.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect, useState } from 'react';
 import { isHex, isNumber } from '@polkadot/util';
 import { randomAsHex } from '@polkadot/util-crypto';

--- a/src/ui/components/instantiate/Step3.tsx
+++ b/src/ui/components/instantiate/Step3.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { formatBalance, formatNumber } from '@polkadot/util';
 import { useParams } from 'react-router';

--- a/src/ui/components/instantiate/Stepper.tsx
+++ b/src/ui/components/instantiate/Stepper.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { CheckIcon } from '@heroicons/react/outline';
 import { classes } from 'ui/util';

--- a/src/ui/components/instantiate/Wizard.tsx
+++ b/src/ui/components/instantiate/Wizard.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Step1 } from './Step1';
 import { Step2 } from './Step2';

--- a/src/ui/components/instantiate/index.ts
+++ b/src/ui/components/instantiate/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './AvailableCodeBundles';
 export * from './LookUpCodeHash';
 export * from './Wizard';

--- a/src/ui/components/message/ArgSignature.tsx
+++ b/src/ui/components/message/ArgSignature.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { encodeTypeDef } from '@polkadot/types/create';
 import { useApi } from 'ui/contexts/ApiContext';
@@ -8,7 +5,7 @@ import { TypeDef } from 'types';
 import { classes } from 'ui/util';
 
 interface Props extends React.HTMLAttributes<HTMLDivElement> {
-  arg: { name?: string, type: TypeDef };
+  arg: { name?: string; type: TypeDef };
   value?: string;
 }
 
@@ -28,7 +25,9 @@ export function ArgSignature({ arg: { name, type }, children, className, value, 
   return (
     <span className={classes('font-mono', className)} {...props}>
       {name ? `${name}: ` : ''}
-      <span>{value ? <b>{truncate(value)}</b> : (type.typeName || encodeTypeDef(api.registry, type))}</span>
+      <span>
+        {value ? <b>{truncate(value)}</b> : type.typeName || encodeTypeDef(api.registry, type)}
+      </span>
       {children}
     </span>
   );

--- a/src/ui/components/message/MessageDocs.tsx
+++ b/src/ui/components/message/MessageDocs.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/src/ui/components/message/MessageSignature.tsx
+++ b/src/ui/components/message/MessageSignature.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { encodeTypeDef } from '@polkadot/types/create';
 import { DatabaseIcon } from '@heroicons/react/outline';

--- a/src/ui/components/message/index.ts
+++ b/src/ui/components/message/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './ArgSignature';
 export * from './MessageDocs';
 export * from './MessageSignature';

--- a/src/ui/components/modal/HelpModal.tsx
+++ b/src/ui/components/modal/HelpModal.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { ChevronRightIcon } from '@heroicons/react/outline';
 import { BookOpenIcon } from '@heroicons/react/solid';

--- a/src/ui/components/modal/Logos.tsx
+++ b/src/ui/components/modal/Logos.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 
 export const GithubLogo = () => {

--- a/src/ui/components/modal/ModalBase.tsx
+++ b/src/ui/components/modal/ModalBase.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { Dialog, Transition } from '@headlessui/react';
 import { XIcon } from '@heroicons/react/solid';
 import React, { Fragment } from 'react';

--- a/src/ui/components/modal/index.ts
+++ b/src/ui/components/modal/index.ts
@@ -1,4 +1,1 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './HelpModal';

--- a/src/ui/components/sidebar/Footer.tsx
+++ b/src/ui/components/sidebar/Footer.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useState } from 'react';
 import { ChatAltIcon, CogIcon } from '@heroicons/react/outline';
 import { Link } from 'react-router-dom';

--- a/src/ui/components/sidebar/NavLink.tsx
+++ b/src/ui/components/sidebar/NavLink.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { NavLink as NavLinkBase, NavLinkProps } from 'react-router-dom';
 

--- a/src/ui/components/sidebar/Navigation.tsx
+++ b/src/ui/components/sidebar/Navigation.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { DocumentAddIcon, CollectionIcon } from '@heroicons/react/outline';
 import { NavLink } from './NavLink';

--- a/src/ui/components/sidebar/NetworkAndUser.tsx
+++ b/src/ui/components/sidebar/NetworkAndUser.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { useNavigate } from 'react-router';
 import { Dropdown } from '../common/Dropdown';

--- a/src/ui/components/sidebar/QuickLinks.tsx
+++ b/src/ui/components/sidebar/QuickLinks.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { DocumentTextIcon } from '@heroicons/react/outline';
 import { Link } from 'react-router-dom';

--- a/src/ui/components/sidebar/index.tsx
+++ b/src/ui/components/sidebar/index.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Footer } from './Footer';
 import { Navigation } from './Navigation';

--- a/src/ui/contexts/ApiContext.tsx
+++ b/src/ui/contexts/ApiContext.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useReducer, useEffect, useContext } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { INIT_STATE, RPCS } from '../../constants';

--- a/src/ui/contexts/DatabaseContext.tsx
+++ b/src/ui/contexts/DatabaseContext.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, {
   HTMLAttributes,
   useCallback,

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useState, useContext, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { BN_THOUSAND } from '@polkadot/util';

--- a/src/ui/contexts/ThemeContext.tsx
+++ b/src/ui/contexts/ThemeContext.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useContext, useEffect } from 'react';
 import { useLocalStorage } from 'ui/hooks/useLocalStorage';
 

--- a/src/ui/contexts/TransactionsContext.tsx
+++ b/src/ui/contexts/TransactionsContext.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useState, useContext, useEffect } from 'react';
 import { web3FromAddress } from '@polkadot/extension-dapp';
 import { useApi } from './ApiContext';

--- a/src/ui/contexts/index.tsx
+++ b/src/ui/contexts/index.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './ApiContext';
 export * from './DatabaseContext';
 export * from './InstantiateContext';

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './useCodeBundle';
 export * from './useCodeBundleSearch';
 export * from './useContract';

--- a/src/ui/hooks/useAccount.ts
+++ b/src/ui/hooks/useAccount.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { KeyringAddress } from '@polkadot/ui-keyring/types';
 import { useMemo } from 'react';
 import { useApi } from 'ui/contexts';

--- a/src/ui/hooks/useAccountId.ts
+++ b/src/ui/hooks/useAccountId.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useFormField } from './useFormField';
 import { useApi } from 'ui/contexts/ApiContext';

--- a/src/ui/hooks/useArgValues.ts
+++ b/src/ui/hooks/useArgValues.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useEffect, useState } from 'react';
 import { useApi } from 'ui/contexts/ApiContext';
 import { AbiParam, ApiPromise, Keyring, SetState } from 'types';

--- a/src/ui/hooks/useAvailableCodeBundles.ts
+++ b/src/ui/hooks/useAvailableCodeBundles.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import compareDesc from 'date-fns/compareDesc';
 import parseISO from 'date-fns/parseISO';

--- a/src/ui/hooks/useBalance.ts
+++ b/src/ui/hooks/useBalance.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { BN_ONE, BN_TWO, BN_ZERO, isBn } from '@polkadot/util';
 import BN from 'bn.js';
 import { useCallback } from 'react';

--- a/src/ui/hooks/useBlockTime.ts
+++ b/src/ui/hooks/useBlockTime.ts
@@ -1,4 +1,3 @@
-/* eslint-disable header/header */
 // Copyright 2017-2021 @polkadot/app-democracy authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/src/ui/hooks/useCodeBundle.ts
+++ b/src/ui/hooks/useCodeBundle.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useApi } from '../contexts/ApiContext';
 import { useDatabase } from '../contexts/DatabaseContext';

--- a/src/ui/hooks/useCodeBundleSearch.ts
+++ b/src/ui/hooks/useCodeBundleSearch.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDbQuery } from './useDbQuery';
 import { searchForCodeBundle } from 'db';

--- a/src/ui/hooks/useContract.ts
+++ b/src/ui/hooks/useContract.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts/DatabaseContext';
 import { useDbQuery } from './useDbQuery';

--- a/src/ui/hooks/useDbQuery.ts
+++ b/src/ui/hooks/useDbQuery.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback, useEffect, useState } from 'react';
 import { useDatabase } from '../contexts/DatabaseContext';
 import type { DbQuery } from 'types';

--- a/src/ui/hooks/useFormField.ts
+++ b/src/ui/hooks/useFormField.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { isNull, isUndefined } from '@polkadot/util';

--- a/src/ui/hooks/useIsMounted.ts
+++ b/src/ui/hooks/useIsMounted.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useEffect, useRef } from 'react';
 
 export function useIsMounted(): boolean {

--- a/src/ui/hooks/useLocalStorage.ts
+++ b/src/ui/hooks/useLocalStorage.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useState } from 'react';
 
 export function useLocalStorage<T>(key: string, initialValue: T): [T, (_: T) => void] {

--- a/src/ui/hooks/useMetadata.ts
+++ b/src/ui/hooks/useMetadata.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { isWasm, u8aToString } from '@polkadot/util';
 import { useEffect, useState } from 'react';
 import { useApi } from 'ui/contexts/ApiContext';

--- a/src/ui/hooks/useMyCodeBundles.ts
+++ b/src/ui/hooks/useMyCodeBundles.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';

--- a/src/ui/hooks/useMyContracts.ts
+++ b/src/ui/hooks/useMyContracts.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';

--- a/src/ui/hooks/useNonEmptyString.ts
+++ b/src/ui/hooks/useNonEmptyString.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useFormField } from './useFormField';
 import type { ValidFormField, Validation } from 'types';

--- a/src/ui/hooks/useNonZeroBn.ts
+++ b/src/ui/hooks/useNonZeroBn.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useMemo } from 'react';
 import { BN_ZERO, bnToBn } from '@polkadot/util';
 import { useFormField } from './useFormField';

--- a/src/ui/hooks/useQueueTx.ts
+++ b/src/ui/hooks/useQueueTx.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { SubmittableResult } from '@polkadot/api';
 import { VoidFn } from '@polkadot/api/types';
 import { isNull } from '@polkadot/util';

--- a/src/ui/hooks/useStatistics.ts
+++ b/src/ui/hooks/useStatistics.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';

--- a/src/ui/hooks/useStepper.ts
+++ b/src/ui/hooks/useStepper.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback, useState } from 'react';
 
 import type { UseStepper } from 'types';

--- a/src/ui/hooks/useToggle.ts
+++ b/src/ui/hooks/useToggle.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback, useEffect, useState } from 'react';
 import { useIsMounted } from './useIsMounted';
 import type { UseToggle } from 'types';

--- a/src/ui/hooks/useToggleContractStar.ts
+++ b/src/ui/hooks/useToggleContractStar.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
 import { starContract, unstarContract } from 'db/queries';

--- a/src/ui/hooks/useTopContracts.ts
+++ b/src/ui/hooks/useTopContracts.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import { useCallback } from 'react';
 import { useDatabase } from '../contexts';
 import { useDbQuery } from './useDbQuery';

--- a/src/ui/hooks/useWeight.ts
+++ b/src/ui/hooks/useWeight.ts
@@ -1,4 +1,3 @@
-/* eslint-disable header/header */
 // Copyright 2017-2021 @polkadot/react-hooks authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { HashRouter, Route, Routes } from 'react-router-dom';

--- a/src/ui/pages/AddContract.tsx
+++ b/src/ui/pages/AddContract.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { ChevronRightIcon, CodeIcon, UploadIcon } from '@heroicons/react/outline';

--- a/src/ui/pages/Contract.tsx
+++ b/src/ui/pages/Contract.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { BookOpenIcon, PlayIcon } from '@heroicons/react/outline';

--- a/src/ui/pages/Homepage.tsx
+++ b/src/ui/pages/Homepage.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Contracts, HelpBox, Statistics } from '../components/homepage';
 import { PageHome } from 'ui/templates';

--- a/src/ui/pages/Instantiate.tsx
+++ b/src/ui/pages/Instantiate.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { InstantiateContextProvider } from 'ui/contexts';

--- a/src/ui/pages/SelectCodeHash.tsx
+++ b/src/ui/pages/SelectCodeHash.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { LookUpCodeHash, AvailableCodeBundles } from 'ui/components/instantiate';

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { Dropdown } from 'ui/components';
 import { useTheme } from 'ui/contexts';

--- a/src/ui/pages/index.ts
+++ b/src/ui/pages/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './AddContract';
 export * from './Contract';
 export * from './Homepage';

--- a/src/ui/reducers/api.ts
+++ b/src/ui/reducers/api.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import type { Reducer } from 'react';
 import { NULL_CHAIN_PROPERTIES } from '../../constants';
 import type { ApiAction, ApiState } from 'types';

--- a/src/ui/reducers/index.ts
+++ b/src/ui/reducers/index.ts
@@ -1,4 +1,1 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './api';

--- a/src/ui/templates/Page.tsx
+++ b/src/ui/templates/Page.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { HTMLAttributes } from 'react';
 
 interface PageProps extends HTMLAttributes<HTMLDivElement> {

--- a/src/ui/templates/PageFull.tsx
+++ b/src/ui/templates/PageFull.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { HTMLAttributes } from 'react';
 
 interface PageProps extends HTMLAttributes<HTMLDivElement> {

--- a/src/ui/templates/PageHome.tsx
+++ b/src/ui/templates/PageHome.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React, { HTMLAttributes } from 'react';
 
 interface Props extends HTMLAttributes<HTMLDivElement> {

--- a/src/ui/templates/index.tsx
+++ b/src/ui/templates/index.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 export * from './Page';
 export * from './PageHome';
 export * from './PageFull';

--- a/src/ui/util/dropdown.tsx
+++ b/src/ui/util/dropdown.tsx
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import React from 'react';
 import { MessageSignature } from '../components/message/MessageSignature';
 import { AbiConstructor, AbiMessage, DropdownOption, ContractDocument, KeyringPair } from 'types';

--- a/src/ui/util/index.ts
+++ b/src/ui/util/index.ts
@@ -1,6 +1,3 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 import format from 'date-fns/format';
 import parseISO from 'date-fns/parseISO';
 import { twMerge } from 'tailwind-merge';

--- a/src/ui/util/initValue.ts
+++ b/src/ui/util/initValue.ts
@@ -1,4 +1,3 @@
-/* eslint-disable header/header */
 // Copyright 2017-2021 @polkadot/react-params authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,1 @@
-// Copyright 2021 @paritytech/contracts-ui authors & contributors
-// SPDX-License-Identifier: Apache-2.0
-
 declare module 'indexeddb-export-import';


### PR DESCRIPTION
The `eslint-header` plugin is forcing you to add the license header on _every_ file
It's unnecessary now that we have a license file.