### PR TITLE
Correctly assign Vector components to `Vec` input types

### DIFF
--- a/src/ui/components/form/findComponent.tsx
+++ b/src/ui/components/form/findComponent.tsx
@@ -34,7 +34,7 @@ export function findComponent(
       />
     );
   }
-  if (type.sub && !Array.isArray(type.sub)) {
+  if (type.info === TypeDefInfo.Vec && type.sub && !Array.isArray(type.sub)) {
     const Component = findComponent(registry, type.sub, nestingNumber + 1);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
     return (props: any) => Vector({ Component, props: { ...props, nestingNumber, type } });


### PR DESCRIPTION
While trying to find a contract with `Option` inputs, i tried to deploy[ the contract ](https://github.com/agryaznov/candle-auction-ink/releases/tag/v0.2.3) used to open the issue in the first place. It resulted in a white screen when going to step 2 of the instantiation form. 
After some debugging, turns out the app was trying to load a Vector component for the Option input.
This PR fixes that, now the app displays the default case, a plain HTML text input 

related to https://github.com/paritytech/contracts-ui/issues/161