### PR TITLE
Display results and events on block inclusion

### DIFF
--- a/src/api/util/index.ts
+++ b/src/api/util/index.ts
@@ -5,7 +5,17 @@ import BN from 'bn.js';
 import { compactAddLength, u8aToU8a, isNumber, BN_TEN } from '@polkadot/util';
 import { randomAsU8a } from '@polkadot/util-crypto';
 import { MAX_CALL_WEIGHT } from '../../constants';
-import { Bytes, ApiPromise, AbiParam, Registry, OrFalsy, Weight } from 'types';
+import {
+  Bytes,
+  ApiPromise,
+  AbiParam,
+  Registry,
+  OrFalsy,
+  Weight,
+  ChainType,
+  SubmittableResult,
+  Hash,
+} from 'types';
 
 const EMPTY_SALT = new Uint8Array();
 
@@ -103,4 +113,15 @@ export function isValidWsUrl(s: unknown) {
     return url.protocol === 'ws:' || url.protocol === 'wss:';
   }
   return false;
+}
+
+export function isResultReady(result: SubmittableResult, systemChainType: ChainType): boolean {
+  return systemChainType.isDevelopment ? result.isInBlock : result.isFinalized;
+}
+
+export function getBlockHash(
+  status: SubmittableResult['status'],
+  systemChainType: ChainType
+): Hash {
+  return systemChainType.isDevelopment ? status.asInBlock : status.asFinalized;
 }

--- a/src/types/substrate.ts
+++ b/src/types/substrate.ts
@@ -9,6 +9,7 @@ export type {
   EventRecord,
   Weight,
   ChainType,
+  Hash,
 } from '@polkadot/types/interfaces';
 export type { KeyringPair } from '@polkadot/keyring/types';
 export type {

--- a/src/types/ui/contract.ts
+++ b/src/types/ui/contract.ts
@@ -9,6 +9,7 @@ import type {
   ContractPromise,
   KeyringPair,
   RegistryError,
+  Hash,
 } from '../substrate';
 
 export interface ContractDryRunParams {
@@ -25,7 +26,7 @@ export interface CallResult {
   isComplete: boolean;
   log: string[];
   message: AbiMessage;
-  blockHash?: string;
+  blockHash?: Hash;
   error?: RegistryError;
   info?: Record<string, AnyJson>;
   time: number;

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -15,6 +15,7 @@ import {
   FormField,
 } from 'ui/components/form';
 import { dryRun, NOOP, prepareContractTx, sendContractQuery, transformUserInput } from 'api';
+import { getBlockHash } from 'api/util';
 import { useApi, useTransactions } from 'ui/contexts';
 import { BN, CallResult, ContractPromise, RegistryError, SubmittableResult } from 'types';
 import { useWeight, useBalance, useArgValues, useFormField, useAccountId } from 'ui/hooks';
@@ -27,7 +28,7 @@ interface Props {
 }
 
 export const InteractTab = ({ contract }: Props) => {
-  const { api, keyring } = useApi();
+  const { api, keyring, systemChainType } = useApi();
   const {
     value: message,
     onChange: setMessage,
@@ -109,7 +110,7 @@ export const InteractTab = ({ contract }: Props) => {
         time: Date.now(),
         log: log,
         error: dispatchError ? contract.registry.findMetaError(dispatchError.asModule) : undefined,
-        blockHash: status.asFinalized.toString(),
+        blockHash: getBlockHash(status, systemChainType),
         info: dispatchInfo?.toHuman(),
       },
     ]);

--- a/src/ui/components/contract/TransactionResult.tsx
+++ b/src/ui/components/contract/TransactionResult.tsx
@@ -60,7 +60,7 @@ export const TransactionResult = ({
                   <div className="pt-4 mb-4">
                     <span className="mr-2">Included at #</span>
                     <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">
-                      {`${blockHash?.slice(0, 6)}...${blockHash?.slice(-4)}`}
+                      {`${blockHash?.toHex().slice(0, 6)}...${blockHash?.toHex().slice(-4)}`}
                     </span>
                   </div>
                   <div>

--- a/src/ui/contexts/TransactionsContext.tsx
+++ b/src/ui/contexts/TransactionsContext.tsx
@@ -6,6 +6,7 @@ import { web3FromAddress } from '@polkadot/extension-dapp';
 import { useApi } from './ApiContext';
 import { TxOptions, TransactionsState, TxStatus as Status, TransactionsQueue } from 'types';
 import { Transactions } from 'ui/components/Transactions';
+import { isResultReady } from 'api/util';
 import { isEmptyObj } from 'ui/util';
 
 let nextId = 1;
@@ -15,7 +16,7 @@ export const TransactionsContext = React.createContext({} as unknown as Transact
 export function TransactionsContextProvider({
   children,
 }: React.PropsWithChildren<Partial<TransactionsState>>) {
-  const { api, keyring } = useApi();
+  const { api, keyring, systemChainType } = useApi();
   const [txs, setTxs] = useState<TransactionsQueue>({});
 
   function queue(options: TxOptions): number {
@@ -51,7 +52,7 @@ export function TransactionsContextProvider({
           accountOrPair,
           { signer: injector?.signer || undefined },
           async result => {
-            if (result.isFinalized) {
+            if (isResultReady(result, systemChainType)) {
               const events: Record<string, number> = {};
 
               result.events.forEach(record => {


### PR DESCRIPTION
Makes no sense to keep the UI blocked until the block is finalized on development chains. This way transactions on the local node finish much sooner. Significantly speeds up e2e tests.

closes https://github.com/paritytech/contracts-ui/issues/230