### PR TITLE
Better error messages in the app

### DIFF
--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -97,7 +97,7 @@ export interface TxOptions {
   accountId: string;
   isValid: (_: SubmittableResult) => boolean;
   onSuccess?: ((_: SubmittableResult) => void) | ((_: SubmittableResult) => Promise<void>);
-  onError?: () => void;
+  onError?: (result: SubmittableResult) => void;
 }
 
 export interface QueuedTxOptions extends TxOptions {

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -14,7 +14,7 @@ import {
   Form,
   FormField,
 } from 'ui/components/form';
-import { dryRun, NOOP, prepareContractTx, sendContractQuery, transformUserInput } from 'api';
+import { dryRun, prepareContractTx, sendContractQuery, transformUserInput } from 'api';
 import { getBlockHash } from 'api/util';
 import { useApi, useTransactions } from 'ui/contexts';
 import { BN, CallResult, ContractPromise, RegistryError, SubmittableResult } from 'types';
@@ -95,7 +95,7 @@ export const InteractTab = ({ contract }: Props) => {
 
   const { queue, process, txs } = useTransactions();
 
-  const onSuccess = ({ status, dispatchInfo, dispatchError, events }: SubmittableResult) => {
+  const onCallSuccess = ({ status, dispatchInfo, events }: SubmittableResult) => {
     const log = events.map(({ event }) => {
       return `${event.section}:${event.method}`;
     });
@@ -108,8 +108,7 @@ export const InteractTab = ({ contract }: Props) => {
         isComplete: true,
         message,
         time: Date.now(),
-        log: log,
-        error: dispatchError ? contract.registry.findMetaError(dispatchError.asModule) : undefined,
+        log,
         blockHash: getBlockHash(status, systemChainType),
         info: dispatchInfo?.toHuman(),
       },
@@ -117,7 +116,26 @@ export const InteractTab = ({ contract }: Props) => {
 
     setNextResultId(nextResultId + 1);
   };
+  const onCallError = ({ events, dispatchError, dispatchInfo }: SubmittableResult) => {
+    const log = events.map(({ event }) => {
+      return `${event.section}:${event.method}`;
+    });
+    setCallResults([
+      ...callResults,
+      {
+        id: nextResultId,
+        message,
+        time: Date.now(),
+        isComplete: true,
+        data: null,
+        error: dispatchError ? contract.registry.findMetaError(dispatchError.asModule) : undefined,
+        log,
+        info: dispatchInfo?.toHuman(),
+      },
+    ]);
 
+    setNextResultId(nextResultId + 1);
+  };
   const read = async () => {
     const { result, output } = await sendContractQuery(
       contract.query[message.method],
@@ -150,15 +168,19 @@ export const InteractTab = ({ contract }: Props) => {
 
   const isValid = (result: SubmittableResult) => !result.isError && !result.dispatchError;
 
-  const onError = NOOP;
-
   const newId = useRef<number>();
 
   const call = () => {
     const tx = prepareContractTx(contract.tx[message.method], options, transformed);
 
     if (tx && accountId) {
-      newId.current = queue({ extrinsic: tx, accountId, onSuccess, onError, isValid });
+      newId.current = queue({
+        extrinsic: tx,
+        accountId,
+        onSuccess: onCallSuccess,
+        onError: onCallError,
+        isValid,
+      });
       setTxId(newId.current);
     }
   };

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -148,7 +148,7 @@ export const InteractTab = ({ contract }: Props) => {
     setNextResultId(nextResultId + 1);
   };
 
-  const isValid = (result: SubmittableResult) => !result.isError;
+  const isValid = (result: SubmittableResult) => !result.isError && !result.dispatchError;
 
   const onError = NOOP;
 

--- a/src/ui/components/contract/TransactionResult.tsx
+++ b/src/ui/components/contract/TransactionResult.tsx
@@ -49,24 +49,27 @@ export const TransactionResult = ({
                   />
                 </Disclosure.Button>
                 <Disclosure.Panel>
-                  {error && (
+                  {error ? (
                     <ReactMarkdown
                       // eslint-disable-next-line react/no-children-prop
                       children={error.docs.join('\r\n')}
                       remarkPlugins={[remarkGfm]}
                       className="markdown mt-4 mb-4"
                     />
+                  ) : (
+                    <>
+                      <div className="pt-4 mb-4">
+                        <span className="mr-2">Included at #</span>
+                        <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">
+                          {`${blockHash?.toHex().slice(0, 6)}...${blockHash?.toHex().slice(-4)}`}
+                        </span>
+                      </div>
+                      <div>
+                        <span className="mr-2">Weight</span>
+                        <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">{`${info?.weight}`}</span>
+                      </div>
+                    </>
                   )}
-                  <div className="pt-4 mb-4">
-                    <span className="mr-2">Included at #</span>
-                    <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">
-                      {`${blockHash?.toHex().slice(0, 6)}...${blockHash?.toHex().slice(-4)}`}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="mr-2">Weight</span>
-                    <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">{`${info?.weight}`}</span>
-                  </div>
                 </Disclosure.Panel>
               </>
             )}

--- a/src/ui/components/contract/TransactionResult.tsx
+++ b/src/ui/components/contract/TransactionResult.tsx
@@ -4,8 +4,6 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ChevronUpIcon } from '@heroicons/react/solid';
-import { Disclosure } from '@headlessui/react';
 import { MessageSignature } from '../message/MessageSignature';
 import { Spinner } from '../common/Spinner';
 import type { CallResult } from 'types';
@@ -16,66 +14,43 @@ interface Props {
 }
 
 export const TransactionResult = ({
-  result: { isComplete, time, message, blockHash, info, error, log },
+  result: { isComplete, time, message, error, log },
   date,
 }: Props) => {
   return (
-    <Disclosure>
-      {({ open }) => (
-        <div
-          key={`${time}`}
-          className="text-xs dark:text-gray-400 text-gray-600 break-all p-4 border-b border-gray-200 dark:border-gray-700"
-        >
-          <div className="flex-col">
-            <div className="mb-2">{date}</div>
-            <MessageSignature message={message} />
-            {!isComplete && <Spinner width={4} strokeWidth={2} color="gray-600" className="mt-2" />}
-            {isComplete && (
-              <>
-                <Disclosure.Button className="flex items-center w-full text-left pt-2">
-                  <div className="flex-col items-start">
-                    <div className="event-log">
-                      {log.map((line, index) => (
-                        <p key={index} className="mb-2">
-                          {line}
-                        </p>
-                      ))}
-                    </div>
-                  </div>
-                  <ChevronUpIcon
-                    className={`${
-                      open ? 'transform rotate-180' : ''
-                    } w-4 h-4 ml-auto border-gray-500 `}
-                  />
-                </Disclosure.Button>
-                <Disclosure.Panel>
-                  {error ? (
-                    <ReactMarkdown
-                      // eslint-disable-next-line react/no-children-prop
-                      children={error.docs.join('\r\n')}
-                      remarkPlugins={[remarkGfm]}
-                      className="markdown mt-4 mb-4"
-                    />
-                  ) : (
-                    <>
-                      <div className="pt-4 mb-4">
-                        <span className="mr-2">Included at #</span>
-                        <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">
-                          {`${blockHash?.toHex().slice(0, 6)}...${blockHash?.toHex().slice(-4)}`}
-                        </span>
-                      </div>
-                      <div>
-                        <span className="mr-2">Weight</span>
-                        <span className="text-mono p-1 dark:bg-elevation-1 bg-gray-200">{`${info?.weight}`}</span>
-                      </div>
-                    </>
-                  )}
-                </Disclosure.Panel>
-              </>
-            )}
-          </div>
-        </div>
-      )}
-    </Disclosure>
+    <div
+      key={`${time}`}
+      className="text-xs dark:text-gray-400 text-gray-600 break-all p-4 border-b border-gray-200 dark:border-gray-700"
+    >
+      <div className="flex-col">
+        <div className="mb-2">{date}</div>
+        <MessageSignature message={message} />
+        {!isComplete && <Spinner width={4} strokeWidth={2} color="gray-600" className="mt-2" />}
+        {isComplete && (
+          <>
+            <div className="flex-col items-start mb-2 mt-4">
+              <div className="event-log">
+                {log.map((line, index) => (
+                  <p key={index} className="mb-2">
+                    {line}
+                  </p>
+                ))}
+              </div>
+            </div>
+          </>
+        )}
+        {error && (
+          <>
+            <span className="mb-2">{`${error.section}:${error.method}`}</span>
+            <ReactMarkdown
+              // eslint-disable-next-line react/no-children-prop
+              children={error.docs.join('\r\n')}
+              remarkPlugins={[remarkGfm]}
+              className="markdown mt-2"
+            />
+          </>
+        )}
+      </div>
+    </div>
   );
 };

--- a/src/ui/components/instantiate/DryRun.tsx
+++ b/src/ui/components/instantiate/DryRun.tsx
@@ -7,12 +7,15 @@ import { CheckCircleIcon, ExclamationCircleIcon } from '@heroicons/react/outline
 import { SidePanel } from '../common/SidePanel';
 import { Account } from '../account/Account';
 import { useApi, useInstantiate } from 'ui/contexts';
-// import { fromSats } from 'api';
-// import { fromSats } from 'api';
 
 export function DryRun() {
   const { api } = useApi();
   const { dryRunResult } = useInstantiate();
+
+  const dryRunError =
+    dryRunResult?.result.isErr && dryRunResult?.result.asErr.isModule
+      ? api.registry.findMetaError(dryRunResult?.result.asErr.asModule)
+      : null;
 
   return (
     <SidePanel className="instantiate-outcome" header="Predicted Outcome">
@@ -59,11 +62,14 @@ export function DryRun() {
               The instantiation will be successful.
             </div>
           )}
-          {dryRunResult?.result.isErr && dryRunResult?.result.asErr.isModule && (
+          {dryRunError && dryRunResult && (
             <>
-              <div className="validation error text-mono font-bold">
-                <ExclamationCircleIcon className="mr-3" />
-                {api.registry.findMetaError(dryRunResult?.result.asErr.asModule).name}
+              <div className="validation error text-mono font-bold items-start">
+                <ExclamationCircleIcon className="mr-3" style={{ marginTop: 1 }} />
+                <div>
+                  <p>{dryRunError.name}</p>
+                  <p>{dryRunError.docs}</p>
+                </div>
               </div>
               {dryRunResult.debugMessage.length > 0 && (
                 <div className="validation error block text-mono break-words pl-4 mt-1">

--- a/src/ui/contexts/TransactionsContext.tsx
+++ b/src/ui/contexts/TransactionsContext.tsx
@@ -35,7 +35,7 @@ export function TransactionsContextProvider({
     const tx = txs[id];
 
     if (tx) {
-      const { extrinsic, accountId, isValid, onSuccess } = tx;
+      const { extrinsic, accountId, isValid, onSuccess, onError } = tx;
 
       setTxs({ ...txs, [id]: { ...tx, status: Status.Processing } });
 
@@ -74,6 +74,9 @@ export function TransactionsContextProvider({
                   const decoded = api.registry.findMetaError(result.dispatchError.asModule);
                   message = `${decoded.section.toUpperCase()}.${decoded.method}: ${decoded.docs}`;
                 }
+
+                onError && onError(result);
+
                 throw new Error(message);
               }
 


### PR DESCRIPTION
Currently when a contract call fails, the app shows a success notification and no error message anywhere. 
This PR prints humanly readable errors in the results panel and displays an error notification as expected. 
Other than that, error docs are now displayed in the instantiate dry run results. Something similar should be done with the next iteration of the Interact page, but this should work for now.

closes https://github.com/paritytech/contracts-ui/issues/239
closes https://github.com/paritytech/contracts-ui/issues/27