### PR TITLE
Fix connection error on `contracts-node` 0.11.0

### DIFF
--- a/src/api/chainProps.ts
+++ b/src/api/chainProps.ts
@@ -3,68 +3,41 @@
 
 import { TypeRegistry } from '@polkadot/types/create';
 import { DEFAULT_DECIMALS } from '../constants';
-import { blockTimeMs } from 'api/util/blockTime';
+// import { blockTimeMs } from 'api/util/blockTime';
 import { ChainProperties, ApiPromise } from 'types';
 
 const registry = new TypeRegistry();
 
-async function getChainProperties(api: ApiPromise): Promise<ChainProperties | null> {
-  const blockNumber = (await api.rpc.chain.getHeader()).number.toNumber();
+export async function getChainProperties(api: ApiPromise): Promise<ChainProperties | null> {
+  const [chainProperties, genesisHash, systemName, systemVersion, systemChain, systemChainType] =
+    await Promise.all([
+      api.rpc.system.properties(),
+      api.query.system.blockHash(0),
+      api.rpc.system.name(),
+      api.rpc.system.version(),
+      (await api.rpc.system.chain()).toString(),
+      api.rpc.system.chainType
+        ? api.rpc.system.chainType()
+        : Promise.resolve(registry.createType('ChainType', 'Live')),
+      api.rpc.system,
+    ]);
 
-  if (blockNumber > 1) {
-    const [chainProperties, blockOneHash, systemName, systemVersion, systemChain, systemChainType] =
-      await Promise.all([
-        api.rpc.system.properties(),
-        api.query.system.blockHash(1),
-        api.rpc.system.name(),
-        api.rpc.system.version(),
-        (await api.rpc.system.chain()).toString(),
-        api.rpc.system.chainType
-          ? api.rpc.system.chainType()
-          : Promise.resolve(registry.createType('ChainType', 'Live')),
-        api.rpc.system,
-      ]);
+  const result = {
+    genesisHash: genesisHash.toString(),
+    systemName: systemName.toString(),
+    systemVersion: systemVersion.toString(),
+    systemChainType,
+    systemChain,
+    tokenDecimals: chainProperties.tokenDecimals.isSome
+      ? chainProperties.tokenDecimals.unwrap().toArray()[0].toNumber()
+      : DEFAULT_DECIMALS,
+    tokenSymbol: chainProperties.tokenSymbol.isSome
+      ? chainProperties.tokenSymbol
+          .unwrap()
+          .toArray()
+          .map(s => s.toString())[0]
+      : 'Unit',
+  };
 
-    const result = {
-      blockOneHash: blockOneHash.toString(),
-      systemName: systemName.toString(),
-      systemVersion: systemVersion.toString(),
-      systemChainType,
-      systemChain,
-      tokenDecimals: chainProperties.tokenDecimals.isSome
-        ? chainProperties.tokenDecimals.unwrap().toArray()[0].toNumber()
-        : DEFAULT_DECIMALS,
-      tokenSymbol: chainProperties.tokenSymbol.isSome
-        ? chainProperties.tokenSymbol
-            .unwrap()
-            .toArray()
-            .map(s => s.toString())[0]
-        : 'Unit',
-    };
-
-    return result;
-  }
-
-  return null;
-}
-
-export async function getChainPropertiesWhenReady(api: ApiPromise) {
-  let chainProperties = await getChainProperties(api);
-
-  if (!chainProperties) {
-    chainProperties = await new Promise(resolve => {
-      const interval = setInterval(() => {
-        getChainProperties(api)
-          .then(result => {
-            if (result) {
-              clearInterval(interval);
-              resolve(result);
-            }
-          })
-          .catch(console.error);
-      }, blockTimeMs(api).toNumber());
-    });
-  }
-
-  return chainProperties;
+  return result;
 }

--- a/src/api/chainProps.ts
+++ b/src/api/chainProps.ts
@@ -3,7 +3,6 @@
 
 import { TypeRegistry } from '@polkadot/types/create';
 import { DEFAULT_DECIMALS } from '../constants';
-// import { blockTimeMs } from 'api/util/blockTime';
 import { ChainProperties, ApiPromise } from 'types';
 
 const registry = new TypeRegistry();

--- a/src/api/connect.ts
+++ b/src/api/connect.ts
@@ -3,7 +3,7 @@
 
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { isValidWsUrl } from './util';
-import { getChainPropertiesWhenReady } from './chainProps';
+import { getChainProperties } from './chainProps';
 import { ApiAction } from 'types';
 
 export const connect = (endpoint: string, dispatch: React.Dispatch<ApiAction>) => {
@@ -22,14 +22,14 @@ export const connect = (endpoint: string, dispatch: React.Dispatch<ApiAction>) =
 
     dispatch({
       type: 'CONNECT_READY',
-      payload: await getChainPropertiesWhenReady(_api),
+      payload: await getChainProperties(_api),
     });
   });
 
   _api.on('ready', async () => {
     dispatch({
       type: 'CONNECT_READY',
-      payload: await getChainPropertiesWhenReady(_api),
+      payload: await getChainProperties(_api),
     });
   });
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -13,7 +13,7 @@ export const DEFAULT_DECIMALS = 12;
 export const MAX_CALL_WEIGHT = new BN(2_000_000_000_000);
 
 export const NULL_CHAIN_PROPERTIES = {
-  blockOneHash: null,
+  genesisHash: null,
   systemName: null,
   systemVersion: null,
   tokenDecimals: DEFAULT_DECIMALS,

--- a/src/db/util/init.ts
+++ b/src/db/util/init.ts
@@ -19,14 +19,14 @@ function isLocalNode(rpcUrl: string): boolean {
   return rpcUrl.includes('127.0.0.1');
 }
 
-function purgeOutdatedDBs(blockOneHash: string) {
+function purgeOutdatedDBs(genesisHash: string) {
   // TODO: Investigate use of indexedDB.databases() - not present in Firefox?
   const oldLocalDbName = window.localStorage.getItem(LOCAL_NODE_DB_NAME);
 
   if (oldLocalDbName) {
     const [url, hash] = oldLocalDbName.split(DELIMITER);
 
-    if (isLocalNode(url) && hash !== blockOneHash) {
+    if (isLocalNode(url) && hash !== genesisHash) {
       console.log(`Deleting database ${oldLocalDbName}...`);
       indexedDB.deleteDatabase(oldLocalDbName);
     }
@@ -35,10 +35,10 @@ function purgeOutdatedDBs(blockOneHash: string) {
 
 export async function init(
   rpcUrl: string,
-  blockOneHash: string,
+  genesisHash: string,
   isRemote = false
 ): Promise<[DB, UserDocument | null, PrivateKey | null]> {
-  const name = `${rpcUrl}${DELIMITER}${blockOneHash}`;
+  const name = `${rpcUrl}${DELIMITER}${genesisHash}`;
 
   const db = await initDb(name);
   const [user, identity] = await initIdentity(db);
@@ -48,7 +48,7 @@ export async function init(
   }
 
   if (isLocalNode(rpcUrl)) {
-    purgeOutdatedDBs(blockOneHash);
+    purgeOutdatedDBs(genesisHash);
 
     window.localStorage.setItem(LOCAL_NODE_DB_NAME, name);
   }

--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -40,7 +40,7 @@ export type ApiAction =
   | { type: 'KEYRING_ERROR' };
 
 export interface ChainProperties {
-  blockOneHash: string | null;
+  genesisHash: string | null;
   tokenDecimals: number;
   systemName: string | null;
   systemVersion: string | null;

--- a/src/ui/contexts/DatabaseContext.tsx
+++ b/src/ui/contexts/DatabaseContext.tsx
@@ -23,7 +23,7 @@ const INITIAL = { isDbReady: false } as unknown as DbState;
 export function DatabaseContextProvider({
   children,
 }: HTMLAttributes<HTMLDivElement>): JSX.Element | null {
-  const { status, blockOneHash, endpoint } = useApi();
+  const { status, genesisHash, endpoint } = useApi();
 
   const [state, setState] = useState<DbState>(INITIAL);
 
@@ -34,15 +34,15 @@ export function DatabaseContextProvider({
 
   useEffect((): void => {
     status === 'READY' &&
-      !!blockOneHash &&
-      init(endpoint, blockOneHash, isRemote)
+      !!genesisHash &&
+      init(endpoint, genesisHash, isRemote)
         .then(([db, user, identity]): void => {
           setState(state => ({ ...state, db, user, identity, isDbReady: true }));
         })
         .catch(e => {
           console.error(e);
         });
-  }, [blockOneHash, endpoint, isRemote, status]);
+  }, [genesisHash, endpoint, isRemote, status]);
 
   const refreshUserData = useCallback(async (): Promise<void> => {
     const user = await getUser(state.db, state.identity);


### PR DESCRIPTION
App doesn't connect to the latest version of `contracts-node` because it endlessly waits for block#1 to initialize the db and that doesn't happen automatically anymore