### PR TITLE
Add not found route

### DIFF
--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -7,7 +7,15 @@ import { HashRouter, Route, Routes } from 'react-router-dom';
 import App from 'ui/components/App';
 import './styles/main.css';
 import '@polkadot/api-augment';
-import { AddContract, Contract, Homepage, Instantiate, SelectCodeHash, Settings } from 'ui/pages';
+import {
+  AddContract,
+  Contract,
+  Homepage,
+  Instantiate,
+  SelectCodeHash,
+  Settings,
+  NotFound,
+} from 'ui/pages';
 
 const root = document.getElementById('app-root');
 
@@ -23,6 +31,7 @@ ReactDOM.render(
         </Route>
         <Route path="/contract/:address/" element={<Contract />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>
   </HashRouter>,

--- a/src/ui/pages/NotFound.tsx
+++ b/src/ui/pages/NotFound.tsx
@@ -1,0 +1,22 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import React from 'react';
+import { EmojiSadIcon } from '@heroicons/react/outline';
+import { useNavigate } from 'react-router';
+import { Button } from 'ui/components';
+
+export function NotFound() {
+  const navigate = useNavigate();
+  return (
+    <div className="w-full overflow-y-auto overflow-x-hidden px-5 py-3 m-2 flex justify-center items-center">
+      <div className=" w-7/12 h-60 border dark:border-gray-700 grid place-content-center">
+        <EmojiSadIcon className="w-10 h-10 text-green-400 mb-1 justify-self-center" />
+        <p className="text-sm text-gray-300 mb-6">This page does not exist.</p>
+        <Button onClick={() => navigate('/')} variant="primary" className="justify-self-center">
+          Go Home
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/pages/index.ts
+++ b/src/ui/pages/index.ts
@@ -7,3 +7,4 @@ export * from './Homepage';
 export * from './Instantiate';
 export * from './SelectCodeHash';
 export * from './Settings';
+export * from './NotFound';


### PR DESCRIPTION
closes https://github.com/paritytech/contracts-ui/issues/221

We should consider migrating to `BrowserRouter` when we finally kill GH Pages deployment.
Because of how `HashRouter` works the `NotFound` page isn't loaded when there is no `#` in the url and a default error page is shown.