### PR TITLE
Set deployment base and local port

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,16 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 import tsConfigPaths from 'vite-tsconfig-paths';
 import eslintPlugin from '@nabla/vite-plugin-eslint';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), tsConfigPaths(), eslintPlugin()],
+  base: '/contracts-ui/',
+  server: { port: 8081 },
   build: {
     rollupOptions: {
       output: {
@@ -26,8 +28,8 @@ export default defineConfig({
           }
 
           return 'index';
-        }
-      }
-    }
-  }
-})
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
The vite config was missing the `base` for the deployment URL
Set local port back to 8081 (as it was with webpack)