### PR TITLE
Add copy button, add copiable contract address and identicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bcryptjs": "^2.4.3",
     "big.js": "^6.1.1",
     "buffer": "^6.0.3",
+    "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.28.0",
     "nanoid": "^3.3.1",
     "react": "^18.1.0",

--- a/src/ui/components/account/Identicon.tsx
+++ b/src/ui/components/account/Identicon.tsx
@@ -7,6 +7,7 @@ import type { Circle } from '@polkadot/ui-shared/icons/types';
 import React, { useCallback, useRef } from 'react';
 import { polkadotIcon } from '@polkadot/ui-shared';
 import { classes } from 'ui/util';
+import { Button } from '../common';
 
 export interface Props extends React.HTMLAttributes<HTMLImageElement> {
   value?: string | null;
@@ -25,7 +26,7 @@ function IdenticonBase({
   size,
   style,
 }: Props): React.ReactElement<Props> | null {
-  const ref = useRef<SVGSVGElement>(null);
+  const ref = useRef<HTMLButtonElement>(null);
 
   const onClick = useCallback(() => {
     if (value) {
@@ -40,27 +41,25 @@ function IdenticonBase({
   try {
     return (
       <>
-        <svg
-          className={classes('cursor-copy', className)}
-          data-tip
-          data-for={tooltipId}
-          data-event="click"
-          height={size}
-          id={value ? `identicon-${value}` : undefined}
-          name={value || undefined}
-          onClick={onClick}
-          ref={ref}
-          style={{ ...style, zIndex: 999 }}
-          viewBox="0 0 64 64"
-          width={size}
-        >
-          {polkadotIcon(value || '', { isAlternative }).map(renderCircle)}
-        </svg>
+        <Button data-tip data-for={tooltipId} onClick={onClick} ref={ref} variant="plain">
+          <svg
+            className={classes('cursor-copy', className)}
+            height={size}
+            id={value ? `identicon-${value}` : undefined}
+            name={value || undefined}
+            style={{ ...style, zIndex: 999 }}
+            viewBox="0 0 64 64"
+            width={size}
+          >
+            {polkadotIcon(value || '', { isAlternative }).map(renderCircle)}
+          </svg>
+        </Button>
         <ReactTooltip
           afterShow={() => {
             setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 1000);
           }}
           id={tooltipId}
+          event="none"
         >
           Copied to clipboard
         </ReactTooltip>

--- a/src/ui/components/account/Identicon.tsx
+++ b/src/ui/components/account/Identicon.tsx
@@ -1,9 +1,12 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import ReactTooltip from 'react-tooltip';
+import copy from 'copy-to-clipboard';
 import type { Circle } from '@polkadot/ui-shared/icons/types';
-import React from 'react';
+import React, { useCallback, useRef } from 'react';
 import { polkadotIcon } from '@polkadot/ui-shared';
+import { classes } from 'ui/util';
 
 export interface Props extends React.HTMLAttributes<HTMLImageElement> {
   value?: string | null;
@@ -22,19 +25,44 @@ function IdenticonBase({
   size,
   style,
 }: Props): React.ReactElement<Props> | null {
+  const ref = useRef<SVGSVGElement>(null);
+
+  const onClick = useCallback(() => {
+    if (value) {
+      copy(value);
+    }
+  }, [value]);
+
+  const tooltipId = `identicon-copied-${value}`;
+
   try {
     return (
-      <svg
-        className={className}
-        height={size}
-        id={value || undefined}
-        name={value || undefined}
-        style={style}
-        viewBox="0 0 64 64"
-        width={size}
-      >
-        {polkadotIcon(value || '', { isAlternative }).map(renderCircle)}
-      </svg>
+      <>
+        <svg
+          className={classes('cursor-copy', className)}
+          data-tip
+          data-for={tooltipId}
+          data-event="click"
+          height={size}
+          id={value ? `identicon-${value}` : undefined}
+          name={value || undefined}
+          onClick={onClick}
+          ref={ref}
+          style={{ ...style, zIndex: 999 }}
+          viewBox="0 0 64 64"
+          width={size}
+        >
+          {polkadotIcon(value || '', { isAlternative }).map(renderCircle)}
+        </svg>
+        <ReactTooltip
+          afterShow={() => {
+            setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 3000);
+          }}
+          id={tooltipId}
+        >
+          Copied to clipboard
+        </ReactTooltip>
+      </>
     );
   } catch (e) {
     return null;

--- a/src/ui/components/account/Identicon.tsx
+++ b/src/ui/components/account/Identicon.tsx
@@ -30,6 +30,8 @@ function IdenticonBase({
   const onClick = useCallback(() => {
     if (value) {
       copy(value);
+
+      ref.current && ReactTooltip.show(ref.current);
     }
   }, [value]);
 
@@ -56,7 +58,7 @@ function IdenticonBase({
         </svg>
         <ReactTooltip
           afterShow={() => {
-            setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 3000);
+            setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 1000);
           }}
           id={tooltipId}
         >

--- a/src/ui/components/common/Button.tsx
+++ b/src/ui/components/common/Button.tsx
@@ -1,6 +1,7 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import React from 'react';
 import { classes } from 'ui/util';
 
 type Variant = 'default' | 'primary' | 'plain' | 'negative';
@@ -8,6 +9,7 @@ type Variant = 'default' | 'primary' | 'plain' | 'negative';
 interface Props extends React.HTMLAttributes<HTMLButtonElement> {
   isDisabled?: boolean;
   isLoading?: boolean;
+  ref?: React.MutableRefObject<HTMLButtonElement | null>;
   variant?: Variant;
 }
 
@@ -15,20 +17,16 @@ export function Buttons({ children, className }: React.HTMLAttributes<HTMLButton
   return <div className={classes('flex space-x-2', className)}>{children}</div>;
 }
 
-export function Button({
-  children,
-  className = '',
-  isDisabled = false,
-  isLoading,
-  variant = 'default',
-  ...props
-}: Props) {
+export const Button = React.forwardRef<HTMLButtonElement, Props>((props, ref) => {
+  const { children, variant, className, isDisabled, isLoading, ...rest } = props;
+
   return (
     <button
+      ref={ref}
       type="button"
       className={classes('btn relative', variant, className)}
       {...(isDisabled || isLoading ? { disabled: true } : {})}
-      {...props}
+      {...rest}
     >
       {isLoading && (
         <div
@@ -42,4 +40,4 @@ export function Button({
       <div className={classes('flex', isLoading ? 'invisible' : '')}>{children}</div>
     </button>
   );
-}
+});

--- a/src/ui/components/common/CopyButton.tsx
+++ b/src/ui/components/common/CopyButton.tsx
@@ -1,0 +1,47 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import copy from 'copy-to-clipboard';
+import React, { useCallback, useRef } from 'react';
+import { DocumentDuplicateIcon } from '@heroicons/react/outline';
+import ReactTooltip from 'react-tooltip';
+import { Button } from './Button';
+import { classes } from 'ui/util';
+
+interface Props extends React.HTMLAttributes<unknown> {
+  iconClassName?: string;
+  value: string;
+}
+
+export function CopyButton({ className, iconClassName, value }: Props) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const onClick = useCallback((): void => {
+    copy(value);
+  }, [value]);
+
+  const id = `copyButton-${value}`;
+
+  return (
+    <>
+      <Button
+        className={classes('', className)}
+        data-for={id}
+        data-tip
+        onClick={onClick}
+        ref={ref}
+        variant="plain"
+      >
+        <DocumentDuplicateIcon
+          className={classes('w-4 h-4 hover:text-gray-600 dark:hover:text-gray-300', iconClassName)}
+        />
+      </Button>
+      <ReactTooltip
+        afterShow={() => setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 5000)}
+        id={id}
+        event="click"
+      >
+        Copied to clipboard
+      </ReactTooltip>
+    </>
+  );
+}

--- a/src/ui/components/common/CopyButton.tsx
+++ b/src/ui/components/common/CopyButton.tsx
@@ -17,6 +17,8 @@ export function CopyButton({ className, iconClassName, value }: Props) {
   const ref = useRef<HTMLButtonElement>(null);
   const onClick = useCallback((): void => {
     copy(value);
+
+    ref.current && ReactTooltip.show(ref.current);
   }, [value]);
 
   const id = `copyButton-${value}`;
@@ -36,9 +38,9 @@ export function CopyButton({ className, iconClassName, value }: Props) {
         />
       </Button>
       <ReactTooltip
-        afterShow={() => setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 5000)}
+        afterShow={() => setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 1000)}
         id={id}
-        event="click"
+        event="none"
       >
         Copied to clipboard
       </ReactTooltip>

--- a/src/ui/components/contract/QueryResult.tsx
+++ b/src/ui/components/contract/QueryResult.tsx
@@ -6,6 +6,7 @@ import remarkGfm from 'remark-gfm';
 import { isBn } from '@polkadot/util';
 import { encodeTypeDef } from '@polkadot/types';
 import { MessageSignature } from '../message/MessageSignature';
+import { CopyButton } from '../common/CopyButton';
 import { CallResult } from 'types';
 import { useApi } from 'ui/contexts';
 import { fromSats } from 'api';
@@ -17,6 +18,11 @@ interface Props {
 
 export const QueryResult = ({ result: { time, data, message, error }, date }: Props) => {
   const { api } = useApi();
+
+  const value =
+    message.returnType && encodeTypeDef(api.registry, message.returnType) === 'u128' && isBn(data)
+      ? fromSats(api, data).toString()
+      : data?.toString();
 
   return (
     <div
@@ -31,13 +37,10 @@ export const QueryResult = ({ result: { time, data, message, error }, date }: Pr
         <div className="mb-2">
           <MessageSignature message={message} />
         </div>
-        <div className="dark:bg-elevation-1 bg-gray-200 p-2 rounded-sm text-mono return-value">{`${
-          message.returnType &&
-          encodeTypeDef(api.registry, message.returnType) === 'u128' &&
-          isBn(data)
-            ? fromSats(api, data)
-            : data
-        }`}</div>
+        <div className="dark:bg-elevation-1 bg-gray-200 p-2 rounded-sm text-mono return-value">
+          {value}
+          <CopyButton className="float-right" value={value || ''} />
+        </div>
       </div>
       {error && (
         <ReactMarkdown

--- a/src/ui/components/form/InputGas.tsx
+++ b/src/ui/components/form/InputGas.tsx
@@ -14,6 +14,7 @@ interface Props extends UseWeight, React.HTMLAttributes<HTMLDivElement> {
 
 export function InputGas({
   className,
+  defaultWeight,
   estimatedWeight,
   executionTime,
   isActive,

--- a/src/ui/pages/Contract.tsx
+++ b/src/ui/pages/Contract.tsx
@@ -83,15 +83,15 @@ export function Contract() {
             <div>
               You instantiated this contract{' '}
               <div className="inline-flex items-center">
-                <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 font-mono rounded">
+                <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
                   {truncate(address, 4)}
                 </span>
-                <CopyButton className="ml-1" iconClassName="-mt-1.5" value={address} />
+                <CopyButton className="ml-1" value={address} />
               </div>{' '}
               from{' '}
               <Link
                 to={`/instantiate/${document.codeHash}`}
-                className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 font-mono rounded"
+                className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded"
               >
                 {projectName}
               </Link>{' '}

--- a/src/ui/pages/Contract.tsx
+++ b/src/ui/pages/Contract.tsx
@@ -6,12 +6,13 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { BookOpenIcon, PlayIcon } from '@heroicons/react/outline';
 import { InteractTab } from '../components/contract/Interact';
 import { MetadataTab } from '../components/contract/Metadata';
+import { CopyButton } from '../components/common/CopyButton';
 import { Loader } from '../components/common/Loader';
 import { Tabs } from '../components/common/Tabs';
 import { HeaderButtons } from '../components/common/HeaderButtons';
 import { PageFull } from 'ui/templates';
 import { useContract } from 'ui/hooks';
-import { displayDate } from 'ui/util';
+import { displayDate, truncate } from 'ui/util';
 import { checkOnChainCode } from 'api';
 import { useApi } from 'ui/contexts';
 
@@ -50,7 +51,7 @@ export function Contract() {
 
   const [tabIndex, setTabIndex] = useState(TABS.findIndex(({ id }) => id === activeTab) || 1);
 
-  const [isOnChain, setIsOnChain] = useState(true);
+  const [isOnChain, setIsOnChain] = useState<boolean>();
 
   useEffect(() => {
     data &&
@@ -73,14 +74,21 @@ export function Contract() {
   const projectName = contract?.abi.info.contract.name;
 
   return (
-    <Loader isLoading={!contract && isLoading}>
+    <Loader isLoading={(!contract && isLoading) || isOnChain === undefined}>
       <PageFull
         accessory={<HeaderButtons contract={document} />}
         header={document.name || projectName}
         help={
           isOnChain && (
-            <>
-              You instantiated this contract from{' '}
+            <div>
+              You instantiated this contract{' '}
+              <div className="inline-flex items-center">
+                <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 font-mono rounded">
+                  {truncate(address, 4)}
+                </span>
+                <CopyButton className="ml-1" iconClassName="-mt-1.5" value={address} />
+              </div>{' '}
+              from{' '}
               <Link
                 to={`/instantiate/${document.codeHash}`}
                 className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 font-mono rounded"
@@ -88,7 +96,7 @@ export function Contract() {
                 {projectName}
               </Link>{' '}
               on {displayDate(document.date)}
-            </>
+            </div>
           )
         }
       >

--- a/src/ui/styles/main.css
+++ b/src/ui/styles/main.css
@@ -45,12 +45,21 @@ body {
 }
 
 .__react_component_tooltip {
+  font-family: Karla;
   font-weight: 400;
   font-size: 12px !important;
-  background-color: #1A1D1F !important;
-  border: 1px solid #3A424E !important;
-  opacity: 1 !important;
+  background-color: #1a1d1f !important;
+  border: 1px solid #3a424e !important;
   padding: 4px 12px !important;
+  transition: opacity 0.3s ease-in-out, visibility 0.3s ease-out !important;
+  opacity: 0 !important;
+  visibility: visible;
+  z-index: 1001;
+}
+
+.__react_component_tooltip {
+  visibility: visible;
+  opacity: 1 !important;
 }
 
 @screen xl {

--- a/src/ui/templates/PageFull.tsx
+++ b/src/ui/templates/PageFull.tsx
@@ -25,7 +25,7 @@ export function PageFull({
               <h1 className="text-2xl font-semibold dark:text-white text-gray-700 capitalize">
                 {header}
               </h1>
-              <p className="dark:text-gray-400 text-gray-500 text-sm">{help}</p>
+              <div className="dark:text-gray-400 text-gray-500 text-sm">{help}</div>
             </div>
             <div className="flex flex-col py-4 h-full">
               <div className="-my-2 h-full overflow-x-auto sm:-mx-6 lg:-mx-8">

--- a/src/ui/util/index.ts
+++ b/src/ui/util/index.ts
@@ -11,7 +11,9 @@ export function classes(...classLists: (string | null | undefined | false)[]) {
 
 export function truncate(value: string | undefined, sideLength = 6): string {
   return value
-    ? `${value.substring(0, sideLength)}...${value.substring(value.length - sideLength)}`
+    ? value.length > sideLength * 2
+      ? `${value.substring(0, sideLength)}...${value.substring(value.length - sideLength)}`
+      : value
     : '';
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3085,6 +3085,7 @@ __metadata:
     bcryptjs: ^2.4.3
     big.js: ^6.1.1
     buffer: ^6.0.3
+    copy-to-clipboard: ^3.3.1
     cypress: ^9.6.1
     cypress-file-upload: ^5.0.8
     cypress-wait-until: ^1.7.2
@@ -3126,6 +3127,15 @@ __metadata:
   dependencies:
     safe-buffer: ~5.1.1
   checksum: 985d974a2d33e1a2543ada51c93e1ba2f73eaed608dc39f229afc78f71dcc4c8b7d7c684aa647e3c6a3a204027444d69e53e169ce94e8d1fa8d7dee80c9c8fed
+  languageName: node
+  linkType: hard
+
+"copy-to-clipboard@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "copy-to-clipboard@npm:3.3.1"
+  dependencies:
+    toggle-selection: ^1.0.6
+  checksum: 3c7b1c333dc6a4b2e9905f52e4df6bbd34ff9f9c97ecd3ca55378a6bc1c191bb12a3252e6289c7b436e9188cff0360d393c0161626851d2301607860bbbdcfd5
   languageName: node
   linkType: hard
 
@@ -8475,6 +8485,13 @@ __metadata:
   dependencies:
     is-number: ^7.0.0
   checksum: f76fa01b3d5be85db6a2a143e24df9f60dd047d151062d0ba3df62953f2f697b16fe5dad9b0ac6191c7efc7b1d9dcaa4b768174b7b29da89d4428e64bc0a20ed
+  languageName: node
+  linkType: hard
+
+"toggle-selection@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "toggle-selection@npm:1.0.6"
+  checksum: a90dc80ed1e7b18db8f4e16e86a5574f87632dc729cfc07d9ea3ced50021ad42bb4e08f22c0913e0b98e3837b0b717e0a51613c65f30418e21eb99da6556a74c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes #66 

- Add CopyButton component
- Add copy button to query results and contract address in contract page header
- Copy contract address when identicon is clicked
- Add forwarded ref for Button base component
- Style and z-index adjustments