### PR TITLE
Change testnet name and rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 Substrate Contracts UI is a web application for deploying and interacting with WASM smart contracts on Substrate blockchains that include the FRAME Contracts Pallet.
 
 Supported languages:
+
 - [ink!](https://github.com/paritytech/ink)
 - [ask!](https://github.com/ask-lang/ask)
 - [solang](https://github.com/hyperledger-labs/solang)
 
-
-We recommend running a [Substrate Contracts Node](https://github.com/paritytech/substrate-contracts-node) for local development or using the Canvas parachain on the Rococo Testnet. 
+We recommend running a [Substrate Contracts Node](https://github.com/paritytech/substrate-contracts-node) for local development or using the Contracts parachain on the Rococo Testnet.
 
 ## Features
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,7 +6,7 @@ import type { ApiState } from 'types';
 
 export enum RPC {
   LOCAL = 'ws://127.0.0.1:9944',
-  CANVAS = 'wss://rococo-canvas-rpc.polkadot.io',
+  CONTRACTS = 'wss://rococo-contracts-rpc.polkadot.io',
 }
 export const DEFAULT_DECIMALS = 12;
 

--- a/src/ui/components/common/ConnectionError.tsx
+++ b/src/ui/components/common/ConnectionError.tsx
@@ -30,11 +30,11 @@ function ContractsNodeHelp() {
         <a
           href="#"
           onClick={() => {
-            navigate(`/?rpc=${RPC.CANVAS}`);
+            navigate(`/?rpc=${RPC.CONTRACTS}`);
           }}
           className="text-blue-400"
         >
-          Canvas on Rococo.
+          Contracts parachain on Rococo.
         </a>
       </p>
     </>

--- a/src/ui/components/sidebar/NetworkAndUser.tsx
+++ b/src/ui/components/sidebar/NetworkAndUser.tsx
@@ -13,8 +13,8 @@ const options = [
     value: RPC.LOCAL,
   },
   {
-    label: 'Canvas',
-    value: RPC.CANVAS,
+    label: 'Contracts (Rococo)',
+    value: RPC.CONTRACTS,
   },
 ];
 


### PR DESCRIPTION
Canvas on Rococo was renamed to Contracts