### PR TITLE
Run Cypress tests in CI

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -1,0 +1,24 @@
+name: Prepare
+description: Prepare test environment
+runs:
+  using: composite
+  steps:
+    - name: Download build folder
+      uses: actions/download-artifact@v3
+      with:
+        name: build
+        path: dist
+
+    - name: Download node artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: substrate-contracts-node
+        path: ./
+
+    - name: Start local node
+      shell: bash
+      run: |
+        tar -xvzf substrate-contracts-node-linux.tar.gz
+        cd artifacts/substrate-contracts-node-linux/
+        chmod +x ./substrate-contracts-node
+        ./substrate-contracts-node --dev &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,15 @@ jobs:
           name: build
           path: dist
 
+      - name: Download latest contracts-node
+        run: |
+        'curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
+        -o /usr/local/cargo/bin/substrate-contracts-node && \
+        chmod +x /usr/local/cargo/bin/substrate-contracts-node '
+
+      - name: Start local node
+        run: substrate-contracts-node --dev
+
       - name: 'UI Tests - Chrome'
         uses: cypress-io/github-action@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,14 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          curl -L "https://github.com/paritytech/substrate-contracts-node/releases/download/v0.15.1/substrate-contracts-node-linux.tar.gz" | tar xvz
+          curl -L "https://github.com/paritytech/substrate-contracts-node/releases/download/v0.15.1/substrate-contracts-node-linux.tar.gz" -O
           ls -lash
       - name: Save node artifact
         uses: actions/upload-artifact@v3
         with:
           name: substrate-contracts-node
           if-no-files-found: error
-          path: artifacts/substrate-contracts-node-linux
+          path: substrate-contracts-node-linux.tar.gz
 
   ui-chrome-tests:
     timeout-minutes: 15
@@ -59,16 +59,23 @@ jobs:
           name: build
           path: dist
 
-      - name: Download the node binary
+      - name: Download node artifact
         uses: actions/download-artifact@v3
         with:
           name: substrate-contracts-node
           path: ./
+      - run: ls -lash
 
-      - run: chmod +x ./substrate-contracts-node
+      - name: Extract node binary
+        run: |
+          tar -xvzf substrate-contracts-node-linux.tar.gz
+          ls -lash
 
       - name: Start local node
-        run: ./substrate-contracts-node --dev &
+        run: |
+          cd artifacts/substrate-contracts-node-linux/
+          chmod +x ./substrate-contracts-node
+          ./substrate-contracts-node --dev &
 
       - name: 'UI Tests - Chrome'
         uses: cypress-io/github-action@v2
@@ -83,6 +90,4 @@ jobs:
         env:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-          # Recommended: pass the GitHub token lets this action correctly
-          # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,21 +21,25 @@ jobs:
           name: build
           if-no-files-found: error
           path: dist
-  get-contracts-node:
+
+  contracts-node-binary:
     runs-on: ubuntu-latest
-    container: paritytech/contracts-ci-linux:production
     steps:
+      - run: |
+          curl -L "https://github.com/paritytech/substrate-contracts-node/releases/download/v0.15.1/substrate-contracts-node-linux.tar.gz" | tar xvz
+          ls -lash
       - name: Save node artifact
         uses: actions/upload-artifact@v3
         with:
-          name: local-node-artifact
+          name: substrate-contracts-node
           if-no-files-found: error
-          path: /usr/local/cargo/bin/substrate-contracts-node
+          path: artifacts/substrate-contracts-node-linux
+
   ui-chrome-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container: cypress/browsers:node14.17.0-chrome88-ff89
-    needs: install
+    needs: [install, contracts-node-binary]
     strategy:
       # when one test fails, DO NOT cancel the other
       # containers, because this will kill Cypress processes
@@ -55,8 +59,16 @@ jobs:
           name: build
           path: dist
 
+      - name: Download the node binary
+        uses: actions/download-artifact@v3
+        with:
+          name: substrate-contracts-node
+          path: ./
+
+      - run: chmod +x ./substrate-contracts-node
+
       - name: Start local node
-        run: substrate-contracts-node --dev
+        run: ./substrate-contracts-node --dev
 
       - name: 'UI Tests - Chrome'
         uses: cypress-io/github-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,39 +1,68 @@
-name: 'Build project'
+name: 'Cypress tests'
 
-on:
-  push:
-    branches:
-      - '*' # matches every branch that doesn't contain a '/'
-      - '*/*' # matches every branch containing a single '/'
-      - '**' # matches every branch
-  pull_request:
-    branches:
-      - '*'
-      - '*/*'
-      - '**'
+on: [push]
 
 jobs:
-  build:
+  install:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [14.x]
-
+    container: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Cypress install
+        uses: cypress-io/github-action@v2
         with:
-          node-version: ${{ matrix.node-version }}
-      - name: Cache Node.js modules
-        uses: actions/cache@v2
-        id: yarn-cache
+          runTests: false
+      # report machine parameters
+      - run: yarn cypress info
+      - run: node -p 'os.cpus()'
+      - run: yarn lint
+      - run: yarn build
+
+      - name: Save build folder
+        uses: actions/upload-artifact@v3
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
-      - name: Install dependencies
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn --frozen-lockfile
-      - name: Build
-        run: yarn build
+          name: build
+          if-no-files-found: error
+          path: dist
+  ui-chrome-tests:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    container: cypress/browsers:node14.17.0-chrome88-ff89
+    needs: install
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2, 3, 4, 5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download the build folders
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: dist
+
+      - name: 'UI Tests - Chrome'
+        uses: cypress-io/github-action@v2
+        with:
+          start: yarn start
+          wait-on: 'http://localhost:8081'
+          wait-on-timeout: 120
+          browser: chrome
+          record: true
+          parallel: true
+          group: 'UI - Chrome'
+        env:
+          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          # Recommended: pass the GitHub token lets this action correctly
+          # determine the unique run id necessary to re-run the checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,24 +54,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Download build folder
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: dist
-
-      - name: Download node artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: substrate-contracts-node
-          path: ./
-
-      - name: Start local node
-        run: |
-          tar -xvzf substrate-contracts-node-linux.tar.gz
-          cd artifacts/substrate-contracts-node-linux/
-          chmod +x ./substrate-contracts-node
-          ./substrate-contracts-node --dev &
+      - name: Prepare test environment
+        uses: ./.github/actions/prepare
 
       - name: 'UI Tests - Chrome'
         uses: cypress-io/github-action@v2
@@ -108,24 +92,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Download build folder
-        uses: actions/download-artifact@v3
-        with:
-          name: build
-          path: dist
-
-      - name: Download node artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: substrate-contracts-node
-          path: ./
-
-      - name: Start local node
-        run: |
-          tar -xvzf substrate-contracts-node-linux.tar.gz
-          cd artifacts/substrate-contracts-node-linux/
-          chmod +x ./substrate-contracts-node
-          ./substrate-contracts-node --dev &
+      - name: Prepare test environment
+        uses: ./.github/actions/prepare
 
       - name: 'UI Tests - Firefox'
         uses: cypress-io/github-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Cypress install
-        uses: cypress-io/github-action@v2
-        with:
-          runTests: false
-      # report machine parameters
-      - run: yarn cypress info
-      - run: node -p 'os.cpus()'
-      - run: yarn lint
-      - run: yarn build
+      - name: Install and build
+        run: |
+          yarn
+          yarn build
 
       - name: Save build folder
         uses: actions/upload-artifact@v3
@@ -26,6 +21,7 @@ jobs:
           name: build
           if-no-files-found: error
           path: dist
+
   ui-chrome-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - run: chmod +x ./substrate-contracts-node
 
       - name: Start local node
-        run: ./substrate-contracts-node --dev
+        run: ./substrate-contracts-node --dev &
 
       - name: 'UI Tests - Chrome'
         uses: cypress-io/github-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   install:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
+    container: cypress/browsers:node14.17.0-chrome88-ff89
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,16 @@ jobs:
           name: build
           if-no-files-found: error
           path: dist
-
+  get-contracts-node:
+    runs-on: ubuntu-latest
+    container: paritytech/contracts-ci-linux:production
+    steps:
+      - name: Save node artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: local-node-artifact
+          if-no-files-found: error
+          path: /usr/local/cargo/bin/substrate-contracts-node
   ui-chrome-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -35,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         # run copies of the current job in parallel
-        containers: [1, 2, 3, 4, 5]
+        containers: [1, 2]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,12 +54,6 @@ jobs:
         with:
           name: build
           path: dist
-
-      - name: Download latest contracts-node
-        run: |
-        'curl -L "https://gitlab.parity.io/parity/substrate-contracts-node/-/jobs/artifacts/master/raw/artifacts/substrate-contracts-node-linux/substrate-contracts-node?job=build-linux" \
-        -o /usr/local/cargo/bin/substrate-contracts-node && \
-        chmod +x /usr/local/cargo/bin/substrate-contracts-node '
 
       - name: Start local node
         run: substrate-contracts-node --dev

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,6 @@ on: [push]
 jobs:
   install:
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome88-ff89
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -38,7 +37,9 @@ jobs:
   ui-chrome-tests:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    container: cypress/browsers:node14.17.0-chrome88-ff89
+    container:
+      image: cypress/browsers:node14.15.0-chrome96-ff94
+      options: --user 1001
     needs: [install, contracts-node-binary]
     strategy:
       # when one test fails, DO NOT cancel the other
@@ -82,6 +83,60 @@ jobs:
           record: true
           parallel: true
           group: 'UI - Chrome'
+        env:
+          CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
+          CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  ui-firefox-tests:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node14.15.0-chrome96-ff94
+      options: --user 1001
+    needs: [install, contracts-node-binary]
+    strategy:
+      # when one test fails, DO NOT cancel the other
+      # containers, because this will kill Cypress processes
+      # leaving the Dashboard hanging ...
+      # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
+      matrix:
+        # run copies of the current job in parallel
+        containers: [1, 2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Download build folder
+        uses: actions/download-artifact@v3
+        with:
+          name: build
+          path: dist
+
+      - name: Download node artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: substrate-contracts-node
+          path: ./
+
+      - name: Start local node
+        run: |
+          tar -xvzf substrate-contracts-node-linux.tar.gz
+          cd artifacts/substrate-contracts-node-linux/
+          chmod +x ./substrate-contracts-node
+          ./substrate-contracts-node --dev &
+
+      - name: 'UI Tests - Firefox'
+        uses: cypress-io/github-action@v2
+        with:
+          start: yarn start
+          wait-on: 'http://localhost:8081'
+          wait-on-timeout: 120
+          browser: firefox
+          record: true
+          parallel: true
+          group: 'UI - Firefox'
         env:
           CYPRESS_PROJECT_ID: ${{ secrets.CYPRESS_PROJECT_ID }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Download the build folders
+      - name: Download build folder
         uses: actions/download-artifact@v3
         with:
           name: build
@@ -64,15 +64,10 @@ jobs:
         with:
           name: substrate-contracts-node
           path: ./
-      - run: ls -lash
-
-      - name: Extract node binary
-        run: |
-          tar -xvzf substrate-contracts-node-linux.tar.gz
-          ls -lash
 
       - name: Start local node
         run: |
+          tar -xvzf substrate-contracts-node-linux.tar.gz
           cd artifacts/substrate-contracts-node-linux/
           chmod +x ./substrate-contracts-node
           ./substrate-contracts-node --dev &

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,5 @@ dist
 *.sqlite-journal
 .fuse_*
 .DS_Store
+cypress/screenshots
+cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "projectId": "eup7bh"
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+package = "netlify-plugin-cypress"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,4 @@
 [[plugins]]
 package = "netlify-plugin-cypress"
+  [plugins.inputs.postBuild]
+  enable = true

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,0 @@
-[[plugins]]
-package = "netlify-plugin-cypress"
-  [plugins.inputs.postBuild]
-  enable = true

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "yarn eslint --fix .",
     "format": "yarn prettier --write .",
     "clean": "rm -rf dist",
+    "test": "yarn cypress run",
     "deep-clean": "yarn clean && rm -rf node_modules",
     "regenerate": "yarn deep-clean && yarn && yarn start",
     "postinstall": "husky install"

--- a/src/ui/components/Transactions.tsx
+++ b/src/ui/components/Transactions.tsx
@@ -29,7 +29,11 @@ export function Transactions({
                 <div className="text-gray-400">{status}</div>
               </div>
               {isComplete && (
-                <XIcon className="text-gray-400 w-4 h-4" onClick={() => dismiss(parseInt(id))} />
+                <XIcon
+                  className="text-gray-400 w-4 h-4"
+                  onClick={() => dismiss(parseInt(id))}
+                  data-cy="dismiss-notification"
+                />
               )}
             </div>
             {isComplete && events && !isEmptyObj(events) && (


### PR DESCRIPTION
closes https://github.com/paritytech/contracts-ui/issues/260

Now Cypress tests for Firefox and Chrome are run on push via Github Actions. A `contracts-node` binary is downloaded and stored as artifact, then retrieved and executed in the background in the actual test jobs.
Currently each job runs in 2 containers, but can be scaled up to 5 when we have more tests.

The Cypress Netlify Plugin is no longer needed, the status checks fail in pull requests. 

A dependency of ThreadDB is causing the `yarn install` to fail on `Node.js `> 14 and take a long time in general. 
Should be fixed with https://github.com/paritytech/contracts-ui/pull/302 