### PR TITLE
Refactor ArgValues, add missing component types

### DIFF
--- a/src/types/ui/components.ts
+++ b/src/types/ui/components.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Props as ReactSelectProps } from 'react-select';
+import { Registry, TypeDef } from '../substrate';
 import { ValidFormField } from './hooks';
 import { FileState, OrFalsy, SimpleSpread } from './util';
 
@@ -13,7 +14,11 @@ export interface DropdownOption<T> {
 export type ArgComponentProps<T> = SimpleSpread<
   React.HTMLAttributes<HTMLDivElement>,
   ValidFormField<T>
->;
+> & {
+  registry: Registry;
+  nestingNumber: number;
+  typeDef: TypeDef;
+}
 
 export type DropdownProps<T> = SimpleSpread<
   React.HTMLAttributes<HTMLDivElement>,

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -34,7 +34,7 @@ export const InteractTab = ({ contract }: Props) => {
     onChange: setMessage,
     ...messageValidation
   } = useFormField(contract.abi.messages[0]);
-  const [argValues, setArgValues] = useArgValues(message?.args || []);
+  const [argValues, setArgValues] = useArgValues(contract.registry, message?.args || []);
   const [callResults, setCallResults] = useState<CallResult[]>([]);
   const { value, onChange: setValue, ...valueValidation } = useBalance(100);
   const { value: accountId, onChange: setAccountId, ...accountIdValidation } = useAccountId();

--- a/src/ui/components/form/Enum.tsx
+++ b/src/ui/components/form/Enum.tsx
@@ -6,21 +6,18 @@ import { isNumber } from '@polkadot/util';
 import { Dropdown } from '../common/Dropdown';
 import { ArgSignature } from '../message/ArgSignature';
 import { FormField, getValidation } from './FormField';
-import { OrFalsy, Registry, SimpleSpread, TypeDef, ValidFormField } from 'types';
+import { ArgComponentProps, OrFalsy, Registry, TypeDef } from 'types';
 import { useApi } from 'ui/contexts';
 import { getInitValue } from 'ui/util';
 
-type Props = SimpleSpread<
-  React.InputHTMLAttributes<HTMLInputElement>,
-  ValidFormField<Record<string, unknown>>
-> & {
-  components: React.ComponentType<ValidFormField<unknown>>[];
+type Props = ArgComponentProps<Record<string, unknown>> & {
+  components: React.ComponentType<ArgComponentProps<unknown>>[];
   registry: Registry;
   typeDef: TypeDef;
 };
 
 export function Enum(props: Props) {
-  const { components, typeDef, onChange: _onChange, registry, value = {} } = props;
+  const { components, nestingNumber, typeDef, onChange: _onChange, registry, value = {} } = props;
   const variants = typeDef.sub as TypeDef[];
   const { keyring } = useApi();
   const [variantIndex, _setVariantIndex] = useState<number>(
@@ -65,7 +62,7 @@ export function Enum(props: Props) {
           label={<ArgSignature arg={{ type: variants[variantIndex] }} />}
           {...getValidation(props)}
         >
-          <Component value={Object.values(value)[0]} onChange={onChange} />
+          <Component value={Object.values(value)[0]} onChange={onChange} registry={registry}  nestingNumber={nestingNumber + 1} typeDef={variants[variantIndex]} />
         </FormField>
       )}
     </>

--- a/src/ui/components/form/Option.tsx
+++ b/src/ui/components/form/Option.tsx
@@ -10,7 +10,7 @@ import { getInitValue } from 'ui/util';
 import { useToggle } from 'ui/hooks/useToggle';
 import { NOOP } from 'api';
 
-type Props = SimpleSpread<React.InputHTMLAttributes<HTMLInputElement>, ValidFormField<unknown>> & {
+interface Props extends ArgComponentProps<unknown> & {
   component: React.ComponentType<ValidFormField<unknown> & React.HTMLAttributes<unknown>>;
   registry: Registry;
   typeDef: TypeDef;
@@ -41,6 +41,7 @@ export function Option({
 
   useEffect((): void => {
     if (isSupplied && value === null) {
+      console.log('set initial value');
       onChange(getInitValue(registry, keyring, typeDef.sub as TypeDef));
     } else {
       if (!isSupplied && value !== null) {

--- a/src/ui/components/form/Struct.tsx
+++ b/src/ui/components/form/Struct.tsx
@@ -1,0 +1,44 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { encodeTypeDef } from '@polkadot/types';
+import { TypeDef, ArgComponentProps } from 'types';
+
+type Props = ArgComponentProps<Record<string, unknown>> & {
+  components: React.ComponentType<ArgComponentProps<unknown>>[];
+};
+
+export function Struct ({ components, value, nestingNumber, onChange, registry, typeDef }: Props) {
+  const _onChange = (name: string) => (newEntry: unknown) => {
+    const newValue = { ...value, [name]: newEntry };
+    onChange(newValue);
+  };
+
+  console.log('ass');
+  console.log(typeDef);
+
+  return (
+    <>
+      {typeDef?.sub && components &&
+        components.map((Component, index) => {
+          const subType = (typeDef.sub as TypeDef[])[index];
+          const name = subType.name as string;
+
+          return (
+            <>
+              <label
+                className="block mb-1.5 text-sm font-semibold dark:text-white text-gray-600"
+                key={`${typeDef.name}-label-${index}`}
+                htmlFor={name}
+              >
+                {name}: {encodeTypeDef(registry, subType)}
+              </label>
+              <div key={`${typeDef.name}-component-${index}`} className={'mb-4 mr-1'}>
+                <Component value={value ? value[name] : ''} nestingNumber={nestingNumber + 1} onChange={_onChange(name)} registry={registry} typeDef={subType} />
+              </div>
+            </>
+          )
+        })}
+    </>
+  );
+}

--- a/src/ui/components/form/SubForm.tsx
+++ b/src/ui/components/form/SubForm.tsx
@@ -1,47 +1,24 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { TypeDef, ArgComponentProps } from 'types';
+import { classes } from 'ui/util';
 
-export type SubComponent = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Component: React.ComponentType<any>;
-  name: string;
-};
-
-type Props = ArgComponentProps<Record<string, unknown>> & {
-  components: Array<SubComponent>;
+interface Props extends React.HTMLAttributes<HTMLDivElement> {
   nestingNumber: number;
-  type: TypeDef;
 };
 
-export function SubForm({ components, value, onChange, nestingNumber, type, ...props }: Props) {
-  const _onChange = (name: string) => (newEntry: unknown) => {
-    const newValue = { ...value, [name]: newEntry };
-    onChange(newValue);
-  };
+export function SubForm({ children, className, nestingNumber }: Props) {
   const isOddNesting = nestingNumber % 2 != 0;
+
   return (
     <div
-      className={`p-4 text-left text-sm ${
-        isOddNesting ? 'dark:bg-gray-900 bg-white' : 'dark:bg-elevation-1 bg-gray-100'
-      } rounded border dark:border-gray-500 border-gray-200`}
+      className={classes(
+        'p-4 text-left text-sm rounded border dark:border-gray-500 border-gray-200',
+        isOddNesting ? 'dark:bg-gray-900 bg-white' : 'dark:bg-elevation-1 bg-gray-100',
+        className
+      )}
     >
-      {components &&
-        components.map(({ Component, name }, row) => (
-          <>
-            <label
-              className="block mb-1.5 text-sm font-semibold dark:text-white text-gray-600"
-              key={`${type.name}-label-${row}`}
-              htmlFor={name}
-            >
-              {name}
-            </label>
-            <div key={`${type.name}-component-${row}`} className={'mb-4 mr-1'}>
-              <Component {...props} value={value ? value[name] : ''} onChange={_onChange(name)} />
-            </div>
-          </>
-        ))}
+      {children}
     </div>
   );
 }

--- a/src/ui/components/form/Tuple.tsx
+++ b/src/ui/components/form/Tuple.tsx
@@ -1,0 +1,45 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { encodeTypeDef } from '@polkadot/types';
+import { useCallback } from 'react';
+import { FormField } from './FormField';
+import { ArgComponentProps, OrFalsy, TypeDef } from 'types';
+
+interface Props extends ArgComponentProps<unknown[]> {
+  components: React.ComponentType<ArgComponentProps<unknown>>[];
+};
+
+export function Tuple({ components, nestingNumber, onChange: _onChange, registry, typeDef, value }: Props) {
+  const onChange = useCallback(
+    (index: number) =>
+      (newValue: OrFalsy<unknown>): void => {
+        _onChange(value.map((argAtIndex, atIndex) => (atIndex === index ? newValue : argAtIndex)));
+      },
+    [_onChange, value]
+  );
+
+  return (
+    <div className="flex-1">
+      {components.map((Component, index) => {
+        if (value && value[index]) {
+          const subType = (typeDef.sub as TypeDef[])[index]
+
+          return (
+            <FormField key={`Tuple-${index}`} label={`${index}: ${encodeTypeDef(registry, subType)}`}>
+              <Component
+                onChange={onChange(index)}
+                nestingNumber={nestingNumber + 1}
+                registry={registry}
+                typeDef={subType}
+                value={value[index]}
+              />
+            </FormField>
+          );
+        }
+
+        return null;
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/form/VecFixed.tsx
+++ b/src/ui/components/form/VecFixed.tsx
@@ -1,0 +1,36 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useCallback } from 'react';
+import { OrFalsy, Registry, SimpleSpread, TypeDef, ValidFormField } from 'types';
+
+type Props = SimpleSpread<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  ValidFormField<unknown[]>
+> & {
+  component: React.ComponentType<ValidFormField<unknown> & React.HTMLAttributes<unknown>>;
+  registry: Registry;
+  typeDef: TypeDef;
+};
+
+export function VecFixed({ component: Component, onChange: _onChange, typeDef, value }: Props) {
+  const length = typeDef.length as number;
+
+  const onChange = useCallback(
+    (index: number) =>
+      (newValue: OrFalsy<unknown>): void => {
+        _onChange(value.map((argAtIndex, atIndex) => (atIndex === index ? newValue : argAtIndex)));
+      },
+    [_onChange, value]
+  );
+
+  return (
+    <div className="flex items-start">
+      {[...Array(length).keys()].map((_, index) => {
+        return (
+          <Component key={`VecFixed-${index}`} onChange={onChange(index)} value={value[index]} />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/components/form/VecFixed.tsx
+++ b/src/ui/components/form/VecFixed.tsx
@@ -1,8 +1,13 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { encodeTypeDef } from '@polkadot/types';
 import { useCallback } from 'react';
+import { FormField } from './FormField';
 import { OrFalsy, Registry, SimpleSpread, TypeDef, ValidFormField } from 'types';
+// import { useToggle } from 'ui/hooks/useToggle';
+
+// const INTEGER_TYPES = [ 'i8', 'i16', 'i32', 'i64', 'i128', 'u8', 'u16', 'u32', 'u64', 'u128'];
 
 type Props = SimpleSpread<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -13,7 +18,10 @@ type Props = SimpleSpread<
   typeDef: TypeDef;
 };
 
-export function VecFixed({ component: Component, onChange: _onChange, typeDef, value }: Props) {
+export function VecFixed({ component: Component, onChange: _onChange, registry, typeDef, value }: Props) {
+  // const isEncodeable = INTEGER_TYPES.includes((typeDef.sub as TypeDef).type);
+  // const [isUsingTextInput, setIsUsingTextInput] = useToggle(false);
+
   const length = typeDef.length as number;
 
   const onChange = useCallback(
@@ -25,10 +33,12 @@ export function VecFixed({ component: Component, onChange: _onChange, typeDef, v
   );
 
   return (
-    <div className="flex items-start">
+    <div>
       {[...Array(length).keys()].map((_, index) => {
         return (
-          <Component key={`VecFixed-${index}`} onChange={onChange(index)} value={value[index]} />
+          <FormField key={`VecFixed-${index}`} label={`${index}: ${encodeTypeDef(registry, typeDef.sub as TypeDef)}`}>
+            <Component onChange={onChange(index)} value={value[index]} />
+          </FormField>
         );
       })}
     </div>

--- a/src/ui/components/form/Vector.tsx
+++ b/src/ui/components/form/Vector.tsx
@@ -4,11 +4,9 @@
 import { Button, Buttons } from '../common';
 import { TypeDef, ArgComponentProps } from 'types';
 
-type Props = ArgComponentProps<unknown[]> & {
+interface Props extends ArgComponentProps<unknown[]> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  Component: React.ComponentType<any>;
-  nestingNumber: number;
-  type: TypeDef;
+  component: React.ComponentType<ArgComponentProps<unknown>>;
 };
 
 type TitleProps = {
@@ -28,26 +26,22 @@ const Title = ({ nestingNumber, count, type }: TitleProps) => {
   );
 };
 
-export function Vector({ Component, value, onChange, nestingNumber, type, ...props }: Props) {
+export function Vector({ component: Component, value, onChange, nestingNumber, registry, typeDef, ...props }: Props) {
   const _rowAdd = () => onChange([...value, '']);
   const _rowRemove = () => onChange(value.slice(0, -1));
   const _onChange = (row: number) => (newEntry: unknown) => {
     const newValue = value.map((entry, index) => (index == row ? newEntry : entry));
     onChange(newValue);
   };
-  const isOddNesting = nestingNumber % 2 != 0;
+
   return (
-    <div
-      className={`p-4 text-left text-sm ${
-        isOddNesting ? 'dark:bg-gray-900 bg-white' : 'dark:bg-elevation-1 bg-gray-100'
-      } rounded border dark:border-gray-500 border-gray-200`}
-    >
+    <>
       <div className="flex justify-between align-middle">
         <div className="table mt-2 mb-4">
           <div className="table-cell align-middle font-mono font-bold dark:text-gray-300 text-gray-400">
             <Title
               nestingNumber={nestingNumber}
-              type={(type?.sub as TypeDef)?.type || ''}
+              type={(typeDef?.sub as TypeDef)?.type || ''}
               count={nestingNumber}
             />
           </div>
@@ -93,11 +87,14 @@ export function Vector({ Component, value, onChange, nestingNumber, type, ...pro
             <Component
               key={`component-${row}`}
               {...props}
+              nestingNumber={nestingNumber}
+              registry={registry}
+              typeDef={typeDef}
               value={entry}
               onChange={_onChange(row)}
             />
           </div>
         ))}
-    </div>
+    </>
   );
 }

--- a/src/ui/components/form/findComponent.tsx
+++ b/src/ui/components/form/findComponent.tsx
@@ -10,6 +10,7 @@ import { SubForm, SubComponent } from './SubForm';
 import { Bool } from './Bool';
 import { Enum } from './Enum';
 import { Option } from './Option';
+import { VecFixed } from './VecFixed';
 import { ArgComponentProps, Registry, TypeDef, TypeDefInfo, ValidFormField } from 'types';
 
 // nestingNumber counts the depth of nested components
@@ -27,6 +28,23 @@ export function findComponent(
     return (props: React.PropsWithChildren<ValidFormField<unknown>>) => (
       <Option
         component={findComponent(registry, type.sub as TypeDef)}
+        registry={registry}
+        typeDef={type}
+        {...props}
+      />
+    );
+  }
+
+  if (type.info === TypeDefInfo.VecFixed) {
+    const sub = type.sub as TypeDef;
+
+    if ((type.sub as TypeDef).type === 'u8') {
+      return Input;
+    }
+
+    return (props: React.PropsWithChildren<ValidFormField<unknown[]>>) => (
+      <VecFixed
+        component={findComponent(registry, sub)}
         registry={registry}
         typeDef={type}
         {...props}

--- a/src/ui/components/instantiate/Step2.tsx
+++ b/src/ui/components/instantiate/Step2.tsx
@@ -21,7 +21,7 @@ import { useFormField } from 'ui/hooks/useFormField';
 import { useWeight } from 'ui/hooks/useWeight';
 import { useToggle } from 'ui/hooks/useToggle';
 
-import { AbiMessage, OrFalsy } from 'types';
+import { AbiMessage, OrFalsy, Registry } from 'types';
 import { useStorageDepositLimit } from 'ui/hooks/useStorageDepositLimit';
 import { useDebounce } from 'ui/hooks';
 
@@ -57,7 +57,7 @@ export function Step2() {
   const [constructorIndex, setConstructorIndex] = useState<number>(0);
   const [deployConstructor, setDeployConstructor] = useState<AbiMessage>();
 
-  const [argValues, setArgValues] = useArgValues(deployConstructor?.args || null);
+  const [argValues, setArgValues] = useArgValues(metadata?.registry as Registry, deployConstructor?.args || null);
   const dbArgValues = useDebounce(argValues);
 
   useEffect(() => {

--- a/src/ui/contexts/InstantiateContext.tsx
+++ b/src/ui/contexts/InstantiateContext.tsx
@@ -29,6 +29,7 @@ import {
   maximumBlockWeight,
 } from 'api';
 import { useApi } from 'ui/contexts/ApiContext';
+import { metadata } from '@polkadot/types/interfaces/essentials';
 
 type TxState = [
   SubmittableExtrinsic<'promise'> | null,
@@ -107,10 +108,16 @@ export function InstantiateContextProvider({
   const onFormChange = useCallback(
     async (formData: Step2FormData) => {
       try {
-        const constructor = data.metadata?.findConstructor(formData.constructorIndex);
+        if (!data.metadata || !data.metadata?.registry) {
+          throw new Error('No metadata present');
+        }
+    
+        const constructor = data.metadata.findConstructor(formData.constructorIndex);
 
+        console.log(formData.argValues);
+        
         const inputData = constructor?.toU8a(
-          transformUserInput(apiState.api.registry, constructor.args, formData.argValues)
+          transformUserInput(data.metadata.registry, constructor.args, formData.argValues)
         );
 
         const params = {
@@ -123,7 +130,7 @@ export function InstantiateContextProvider({
           data: inputData,
           salt: formData.salt || undefined,
           value: formData.value
-            ? apiState.api.registry.createType('Balance', formData.value)
+            ? data.metadata.registry.createType('Balance', formData.value)
             : null,
         };
 

--- a/src/ui/hooks/useArgValues.ts
+++ b/src/ui/hooks/useArgValues.ts
@@ -3,32 +3,32 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { useApi } from 'ui/contexts/ApiContext';
-import { AbiParam, ApiPromise, Keyring, SetState } from 'types';
+import { AbiParam, Keyring, Registry, SetState } from 'types';
 import { getInitValue } from 'ui/util';
 
 type ArgValues = Record<string, unknown>;
 
-function fromArgs(api: ApiPromise, keyring: Keyring, args: AbiParam[] | null): ArgValues {
+function fromArgs(registry: Registry, keyring: Keyring, args: AbiParam[] | null): ArgValues {
   const result: ArgValues = {};
 
   (args || []).forEach(({ name, type }) => {
-    result[name] = getInitValue(api.registry, keyring, type);
+    result[name] = getInitValue(registry, keyring, type);
   });
 
   return result;
 }
 
-export function useArgValues(args: AbiParam[] | null): [ArgValues, SetState<ArgValues>] {
-  const { api, keyring } = useApi();
-  const [value, setValue] = useState<ArgValues>(fromArgs(api, keyring, args));
+export function useArgValues(registry: Registry, args: AbiParam[] | null): [ArgValues, SetState<ArgValues>] {
+  const { keyring } = useApi();
+  const [value, setValue] = useState<ArgValues>(fromArgs(registry, keyring, args));
   const argsRef = useRef(args);
 
   useEffect((): void => {
     if (argsRef.current !== args) {
-      setValue(fromArgs(api, keyring, args));
+      setValue(fromArgs(registry, keyring, args));
       argsRef.current = args;
     }
-  }, [api, keyring, args]);
+  }, [registry, keyring, args]);
 
   return [value, setValue];
 }

--- a/src/ui/util/initValue.ts
+++ b/src/ui/util/initValue.ts
@@ -18,6 +18,8 @@ export function getInitValue(registry: Registry, keyring: Keyring, def: TypeDef)
     return getInitValue(registry, keyring, lookupTypeDef);
   } else if (def.info === TypeDefInfo.Option) {
     return null;
+  } else if (def.info === TypeDefInfo.Tuple) {
+    return (def.sub as TypeDef[]).map((subType) => getInitValue(registry, keyring, subType));
   } else if (def.info === TypeDefInfo.Vec) {
     return [getInitValue(registry, keyring, def.sub as TypeDef)];
   } else if (def.info === TypeDefInfo.VecFixed) {
@@ -40,6 +42,9 @@ export function getInitValue(registry: Registry, keyring: Keyring, def: TypeDef)
         }, {})
       : {};
   } else if (def.info === TypeDefInfo.Enum) {
+
+    console.log(def);
+    console.log(Array.isArray(def.sub) ? getInitValue(registry, keyring, def.sub[0]) : null);
     return Array.isArray(def.sub)
       ? { [def.sub[0].name as string]: getInitValue(registry, keyring, def.sub[0]) }
       : {};

--- a/src/ui/util/initValue.ts
+++ b/src/ui/util/initValue.ts
@@ -20,6 +20,15 @@ export function getInitValue(registry: Registry, keyring: Keyring, def: TypeDef)
     return null;
   } else if (def.info === TypeDefInfo.Vec) {
     return [getInitValue(registry, keyring, def.sub as TypeDef)];
+  } else if (def.info === TypeDefInfo.VecFixed) {
+    const value = [];
+    const length = def.length as number;
+
+    for (let i = 0; i < length; i++) {
+      value.push(getInitValue(registry, keyring, def.sub as TypeDef));
+    }
+
+    return value;
   } else if (def.info === TypeDefInfo.Tuple) {
     return Array.isArray(def.sub) ? def.sub.map(def => getInitValue(registry, keyring, def)) : [];
   } else if (def.info === TypeDefInfo.Struct) {


### PR DESCRIPTION
Closes #306, #312

- Add UI components for entering Tuple and FixedVec arguments
- Contract-specific type lookup now uses contract's registry instead of ApiPromise's
- Improve findComponent flow, standardize props for possible argument components
- Refactored Struct/SubForm components
- Refactored Vector component
- Styling changes for argument form