### PR TITLE
Override DispatchError type error field

### DIFF
--- a/src/api/connect.ts
+++ b/src/api/connect.ts
@@ -12,7 +12,15 @@ export const connect = (endpoint: string, dispatch: React.Dispatch<ApiAction>) =
   dispatch({ type: 'CONNECT_INIT' });
 
   const provider = new WsProvider(endpoint);
-  const _api = new ApiPromise({ provider });
+  const _api = new ApiPromise({
+    provider,
+    types: {
+      DispatchErrorModule: {
+        index: 'u8',
+        error: '[u8; 4]',
+      },
+    },
+  });
 
   // Set listeners for disconnection and reconnection event.
   _api.on('connected', async () => {

--- a/src/ui/components/Transactions.tsx
+++ b/src/ui/components/Transactions.tsx
@@ -52,11 +52,7 @@ export function Transactions({
                     );
                   })}
                 </div>
-                <XIcon
-                  className="text-gray-400 w-4 h-4"
-                  data-cy="dismiss-notification"
-                  onClick={() => dismiss(parseInt(id))}
-                />
+                <XIcon className="text-gray-400 w-4 h-4" onClick={() => dismiss(parseInt(id))} />
               </div>
             )}
           </>


### PR DESCRIPTION
Closes #282 

- Overrides DispatchError type to accommodate current substrate-contracts-node metadata