### PR TITLE
Add Shibuya and Shiden to network options

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,6 +7,8 @@ import type { ApiState } from 'types';
 export enum RPC {
   LOCAL = 'ws://127.0.0.1:9944',
   CONTRACTS = 'wss://rococo-contracts-rpc.polkadot.io',
+  SHIBUYA = 'wss://rpc.shibuya.astar.network',
+  SHIDEN = 'wss://rpc.shiden.astar.network',
 }
 export const DEFAULT_DECIMALS = 12;
 

--- a/src/ui/components/sidebar/NetworkAndUser.tsx
+++ b/src/ui/components/sidebar/NetworkAndUser.tsx
@@ -16,6 +16,14 @@ const options = [
     label: 'Contracts (Rococo)',
     value: RPC.CONTRACTS,
   },
+  {
+    label: 'Shibuya',
+    value: RPC.SHIBUYA,
+  },
+  {
+    label: 'Shiden',
+    value: RPC.SHIDEN,
+  },
 ];
 
 export function NetworkAndUser() {


### PR DESCRIPTION
Shibuya and Shiden networks support pallet-contracts.
It would be great if developers could deploy and interact with contracts on these networks via contracts-ui.