### PR TITLE
[WIP] First attempt

### DIFF
--- a/src/types/ui/contexts.ts
+++ b/src/types/ui/contexts.ts
@@ -16,12 +16,19 @@ import type { BN } from './util';
 
 export type Status = 'loading' | 'connected' | 'error';
 
+export type NetworkOptionType = {
+  label: string;
+  value: string;
+};
+
 export interface ApiState extends ChainProperties {
   endpoint: string;
   setEndpoint: (e: string) => void;
   status: Status;
   api: ApiPromise;
   accounts?: Account[];
+  networkOptions: { label: string; value: string }[];
+  setNetworkOptions: (networkOptions: networkOptionType[]) => void;
 }
 
 export interface ChainProperties {

--- a/src/ui/components/sidebar/NetworkAndUser.tsx
+++ b/src/ui/components/sidebar/NetworkAndUser.tsx
@@ -7,27 +7,8 @@ import { RPC } from '../../../constants';
 import { useApi } from 'ui/contexts';
 import { classes } from 'helpers';
 
-const options = [
-  {
-    label: 'Contracts (Rococo)',
-    value: RPC.CONTRACTS,
-  },
-  {
-    label: 'Shibuya',
-    value: RPC.SHIBUYA,
-  },
-  {
-    label: 'Shiden',
-    value: RPC.SHIDEN,
-  },
-  {
-    label: 'Local Node',
-    value: RPC.LOCAL,
-  },
-];
-
 export function NetworkAndUser() {
-  const { endpoint, status } = useApi();
+  const { endpoint, status, networkOptions } = useApi();
   const navigate = useNavigate();
 
   return (
@@ -42,8 +23,8 @@ export function NetworkAndUser() {
         onChange={e => {
           navigate(`/?rpc=${e}`);
         }}
-        options={options}
-        value={options.find(o => o.value === endpoint)?.value || RPC.CONTRACTS}
+        options={networkOptions}
+        value={networkOptions?.find(o => o.value === endpoint)?.value || RPC.CONTRACTS}
       />
     </div>
   );

--- a/src/ui/contexts/ApiContext.tsx
+++ b/src/ui/contexts/ApiContext.tsx
@@ -7,9 +7,28 @@ import { web3Accounts, web3Enable, web3EnablePromise } from '@polkadot/extension
 import { WsProvider } from '@polkadot/api';
 import { keyring } from '@polkadot/ui-keyring';
 import { RPC } from '../../constants';
-import { ApiPromise, ApiState, ChainProperties, Account, Status } from 'types';
+import { ApiPromise, ApiState, ChainProperties, Account, Status, NetworkOptionType } from 'types';
 import { isValidWsUrl, isKeyringLoaded, getChainProperties } from 'helpers';
 import { useLocalStorage } from 'ui/hooks/useLocalStorage';
+
+const options = [
+  {
+    label: 'Contracts (Rococo)',
+    value: RPC.CONTRACTS,
+  },
+  {
+    label: 'Shibuya',
+    value: RPC.SHIBUYA,
+  },
+  {
+    label: 'Shiden',
+    value: RPC.SHIDEN,
+  },
+  {
+    label: 'Local Node',
+    value: RPC.LOCAL,
+  },
+];
 
 export const ApiContext = createContext<ApiState | undefined>(undefined);
 
@@ -25,6 +44,7 @@ export const ApiContextProvider = ({ children }: React.PropsWithChildren<Partial
   const [accounts, setAccounts] = useState<Account[]>();
   const [chainProps, setChainProps] = useState<ChainProperties>();
   const [status, setStatus] = useState<Status>('loading');
+  const [networkOptions, setNetworkOptions] = useState<NetworkOptionType[]>(options);
 
   useEffect(() => {
     if (rpcUrl && isValidWsUrl(rpcUrl) && rpcUrl !== preferredEndpoint) {
@@ -75,6 +95,8 @@ export const ApiContextProvider = ({ children }: React.PropsWithChildren<Partial
         endpoint,
         status,
         ...(chainProps as ChainProperties),
+        networkOptions,
+        setNetworkOptions,
       }}
     >
       {children}

--- a/src/ui/pages/Settings.tsx
+++ b/src/ui/pages/Settings.tsx
@@ -1,9 +1,13 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { Dropdown } from 'ui/components';
-import { useTheme } from 'ui/contexts';
+import { useNavigate } from 'react-router';
+import { Input } from '../components/form';
+import { Button, Buttons, Dropdown } from 'ui/components';
+import { useApi, useTheme } from 'ui/contexts';
 import { Page } from 'ui/templates';
+import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
+import { isValidWsUrl } from 'helpers';
 
 const options = [
   {
@@ -18,6 +22,29 @@ const options = [
 
 export function Settings() {
   const { theme, setTheme } = useTheme();
+  const { value: rpcUrl, onChange: setRpcUrl, ...nameValidation } = useNonEmptyString('wss://');
+  const apiContext = useApi();
+  const navigate = useNavigate();
+
+  const isDisabled = () => {
+    return !(nameValidation.isValid && isValidWsUrl(rpcUrl));
+  };
+
+  const onSave = () => {
+    apiContext.setEndpoint(rpcUrl);
+
+    apiContext.setNetworkOptions(
+      apiContext.networkOptions.map(option => {
+        if (option.label == 'Local Node') {
+          option = { label: 'Local Node', value: rpcUrl };
+        }
+        return option;
+      })
+    );
+
+    navigate(`/?rpc=${rpcUrl}`);
+  };
+
   return (
     <Page header="Settings" help={<>Manage settings and preferences.</>}>
       <div className="pb-10 border-b border-gray-200 dark:border-gray-800 mt-4 dark:text-white text-gray-600">
@@ -33,6 +60,37 @@ export function Settings() {
               options={options}
               value={theme}
             />
+          </div>
+        </div>
+      </div>
+
+      <div className="pb-10 border-b border-gray-200 dark:border-gray-800 mt-4 dark:text-white text-gray-600">
+        <h2 className="text-lg pb-1 mb-2">Node</h2>
+        <div className="grid grid-cols-12 w-full">
+          <div className="flex flex-col col-span-6 lg:col-span-7 2xl:col-span-8 text-sm">
+            <span className="font-semibold">Custom endpoint</span>
+            <span className="dark:text-gray-400 text-gray-500">
+              Use a custom endpoint for local nodes
+            </span>
+          </div>
+          <div className="col-span-6 lg:col-span-5 2xl:col-span-4">
+            <Buttons>
+              <Input
+                id="customEndpoint"
+                value={rpcUrl}
+                width="200px"
+                onChange={setRpcUrl}
+                {...nameValidation}
+              />
+              <Button
+                onClick={onSave}
+                isDisabled={isDisabled()}
+                variant="primary"
+                data-cy="next-btn"
+              >
+                Save
+              </Button>
+            </Buttons>
           </div>
         </div>
       </div>


### PR DESCRIPTION
As described in this [issue](https://github.com/paritytech/contracts-ui/issues/263), the idea was to allow the user to specify a custom (valid) RPC endpoint.
My approach involved the following parts:
[ X ] Add components to handle user interaction (input, button)
[X ] Handle network Options (all RPC endpoints - i.e. Shibuya, local node, etc) in a centralized way using the ApiContextProvider
[ 1/2 X] Make the NetworkAndUser dropdown identify the custom node and accept it.

What is missing:
- The Dropdown does not "accept" the new value of local node, i.e. it still displays the initially specied local RPC node (RPC.local). I suspect a re-rendering of the component is necessary since networkOptions was changed (useEffect?).
- House-keeping (move networkOptions from ContextProvider to a separate class)
- Linting
- Writing Cypress tests
- Making sure tests pass (Cypress)
 