### PR TITLE
Add Aleph Zero Testnet

### DIFF
--- a/cypress/e2e/extension.spec.ts
+++ b/cypress/e2e/extension.spec.ts
@@ -52,6 +52,7 @@ describe('Signer extension flow on live networks', () => {
       ).should('be.visible');
       cy.contains('Contracts on Rococo').should('be.visible');
       cy.contains('Shiden / Shibuya').should('be.visible');
+      cy.contains('Aleph Zero Testnet').should('be.visible');
     });
   });
 });

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -9,6 +9,7 @@ export enum RPC {
   CONTRACTS = 'wss://rococo-contracts-rpc.polkadot.io',
   SHIBUYA = 'wss://rpc.shibuya.astar.network',
   SHIDEN = 'wss://rpc.shiden.astar.network',
+  ALEPHZEROTESTNET = 'wss://ws.test.azero.dev',
 }
 export const DEFAULT_DECIMALS = 12;
 

--- a/src/ui/components/common/AccountsError.tsx
+++ b/src/ui/components/common/AccountsError.tsx
@@ -35,6 +35,13 @@ export function AccountsError() {
       >
         Shiden / Shibuya
       </a>{' '}
+      <a
+        rel="noopener noreferrer"
+        target="_blank"
+        href="https://docs.alephzero.org/smart-contracts-tutorial/deploying-your-contract-to-aleph-zero-testnet#deploying-contracts"
+      >
+        Aleph Zero Testnet
+      </a>{' '}
     </Error>
   );
 }

--- a/src/ui/components/sidebar/NetworkAndUser.tsx
+++ b/src/ui/components/sidebar/NetworkAndUser.tsx
@@ -21,6 +21,10 @@ const options = [
     value: RPC.SHIDEN,
   },
   {
+    label: 'Aleph Zero Testnet',
+    value: RPC.ALEPHZEROTESTNET,
+  },
+  {
     label: 'Local Node',
     value: RPC.LOCAL,
   },


### PR DESCRIPTION
`pallet-contracts` was added to the network several months ago and there are more than 1k contracts deployed. Would be great to allow developers to use `contracts-ui`.