### PR TITLE
fix: cannot instantiate contracts on swanky node

### DIFF
--- a/src/ui/contexts/TransactionsContext.tsx
+++ b/src/ui/contexts/TransactionsContext.tsx
@@ -45,7 +45,7 @@ export function TransactionsContextProvider({
         account,
         { signer: injector?.signer || undefined },
         async result => {
-          if (result.isInBlock) {
+          if (result.isInBlock || result.isFinalized) {
             const events: Record<string, number> = {};
 
             result.events.forEach(record => {


### PR DESCRIPTION
closes https://github.com/paritytech/contracts-ui/issues/396

for some reason `polkadot.js` decodes the transaction result for contract instantiation on the swanky node as successful, finalized but not in block so the UI was confused. added a check for that.