### PR TITLE
fix: add vertical scroll on pages

### DIFF
--- a/src/ui/styles/main.css
+++ b/src/ui/styles/main.css
@@ -36,6 +36,10 @@ body {
   width: calc(100vw - 14rem);
 }
 
+.scroll {
+  overflow: scroll;
+}
+
 .content main {
   width: 100%;
 }

--- a/src/ui/templates/Page.tsx
+++ b/src/ui/templates/Page.tsx
@@ -12,7 +12,7 @@ export function Page({ header, help, children }: PageProps): React.ReactElement<
   return (
     <>
       <div className="w-full mx-auto">
-        <div className="grid md:grid-cols-12 h-full gap-5 px-5 py-3 m-2">
+        <div className="grid md:grid-cols-12 h-full gap-5 px-5 py-3 m-2 scroll">
           <main className="md:col-span-8 p-4">
             <div className="space-y-1 border-b pb-6 dark:border-gray-800 border-gray-200">
               <h1 className="text-2.5xl font-semibold dark:text-white text-gray-700">{header}</h1>


### PR DESCRIPTION
The PR solves lack of scrolling on pages described in the [issue](https://github.com/paritytech/contracts-ui/issues/290).

I have just found a proper place and added a CSS class to add `overflow: scroll`.

https://user-images.githubusercontent.com/1605705/215628784-d98737d7-5b51-477b-8374-2ae52f1a55b7.mp4






