### PR TITLE
refactoring: contract page

### DIFF
--- a/src/types/ui/hooks.ts
+++ b/src/types/ui/hooks.ts
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { VoidFn } from '../substrate';
+import { ContractPromise, VoidFn } from '../substrate';
 import { BN, FileState, MetadataState, Validation } from './util';
 
 export type InputMode = 'estimation' | 'custom';
@@ -39,4 +39,14 @@ export interface UseStorageDepositLimit extends ValidFormField<BN> {
   maximum: BN | undefined;
   isActive: boolean;
   toggleIsActive: () => void;
+}
+
+export interface UIContract extends Pick<ContractPromise, 'abi' | 'tx'> {
+  name: string;
+  displayName: string;
+  date: string;
+  id: number | undefined;
+  type: 'added' | 'instantiated';
+  codeHash: string;
+  address: string;
 }

--- a/src/ui/components/common/HeaderButtons.tsx
+++ b/src/ui/components/common/HeaderButtons.tsx
@@ -7,10 +7,10 @@ import { Link, useNavigate } from 'react-router-dom';
 import { ConfirmModal } from 'ui/components/modal';
 import { useApi, useDatabase } from 'ui/contexts';
 import { getContractInfo, truncate } from 'helpers';
-import type { ContractDocument } from 'types';
+import type { UIContract } from 'types';
 
 interface Props {
-  contract: ContractDocument;
+  contract: UIContract;
 }
 
 export function HeaderButtons({ contract: { address, codeHash } }: Props) {

--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -15,10 +15,10 @@ import {
   ContractExecResult,
   ContractSubmittableResult,
   CallResult,
-  ContractPromise,
   SubmittableResult,
   ContractOptions,
   Balance,
+  UIContract,
 } from 'types';
 import { AccountSelect } from 'ui/components/account';
 import { Dropdown, Button, Buttons } from 'ui/components/common';
@@ -37,7 +37,7 @@ import { useStorageDepositLimit } from 'ui/hooks/useStorageDepositLimit';
 import { createMessageOptions } from 'ui/util/dropdown';
 
 interface Props {
-  contract: ContractPromise;
+  contract: UIContract;
 }
 
 export const InteractTab = ({

--- a/src/ui/components/contract/Metadata.tsx
+++ b/src/ui/components/contract/Metadata.tsx
@@ -1,25 +1,19 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
-import { useLiveQuery } from 'dexie-react-hooks';
 import { Abi } from 'types';
 import { MessageDocs } from 'ui/components/message/MessageDocs';
 import { Button } from 'ui/components/common';
 import { FormField, getValidation, InputFile, useMetadataField } from 'ui/components/form';
-import { useApi, useDatabase } from 'ui/contexts';
+import { useDatabase } from 'ui/contexts';
 
-export const MetadataTab = () => {
+interface Props {
+  abi: Abi;
+  id: number | undefined;
+}
+
+export const MetadataTab = ({ id, abi }: Props) => {
   const { db } = useDatabase();
-  const { api } = useApi();
-  const { address } = useParams();
-  const [abi, setAbi] = useState<Abi>();
-
-  const document = useLiveQuery(() => {
-    return db.contracts.get({ address });
-  });
-
   const {
     file,
     value: metadata,
@@ -31,12 +25,6 @@ export const MetadataTab = () => {
     isValid,
     ...metadataValidation
   } = useMetadataField();
-
-  useEffect(() => {
-    if (!document) return;
-    const newAbi = new Abi(document?.abi, api?.registry.getChainProperties());
-    setAbi(newAbi);
-  }, [api?.registry, document]);
 
   if (!abi) return null;
 
@@ -70,8 +58,8 @@ export const MetadataTab = () => {
           className="flex justify-between items-center px-3 py-2 border text-gray-500 dark:text-gray-300 dark:border-gray-700 border-gray-200 rounded-md dark:bg-elevation-1 dark:enabled:hover:bg-elevation-2"
           isDisabled={!isSupplied || !isValid}
           onClick={async () => {
-            if (!metadata || !document?.id) throw new Error('Unable to update metadata.');
-            await db.contracts.update(document.id, { abi: metadata.json });
+            if (!metadata || !id) throw new Error('Unable to update metadata.');
+            await db.contracts.update(id, { abi: metadata.json });
             onRemove();
           }}
         >

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -10,3 +10,4 @@ export * from './useArgValues';
 export * from './useNewContract';
 export * from './useStorageDepositLimit';
 export * from './useToggle';
+export * from './useStoredContract';

--- a/src/ui/hooks/useStoredContract.ts
+++ b/src/ui/hooks/useStoredContract.ts
@@ -1,0 +1,45 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useLiveQuery } from 'dexie-react-hooks';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { useApi, useDatabase } from 'ui/contexts';
+import { ContractDocument, ContractPromise, UIContract } from 'types';
+
+export function useStoredContract(address: string): UIContract | undefined {
+  const navigate = useNavigate();
+  const { api } = useApi();
+  const { db } = useDatabase();
+  const [contract, setContract] = useState<ContractPromise>();
+  const [document, setDocument] = useState<ContractDocument>();
+
+  useLiveQuery(async () => {
+    // setting to undefined to prevent metadata "leak" on route change
+    // https://github.com/paritytech/contracts-ui/issues/359
+    setContract(undefined);
+    setDocument(undefined);
+    const d = await db.contracts.get({ address });
+    if (!d) {
+      navigate('/');
+    } else {
+      const c = new ContractPromise(api, d.abi, address);
+      setDocument(d);
+      setContract(c);
+    }
+  }, [address]);
+
+  if (!document || !contract) return undefined;
+
+  return {
+    abi: contract.abi,
+    name: contract.abi.info.contract.name.toString(),
+    displayName: document.name,
+    tx: contract.tx,
+    codeHash: document.codeHash,
+    address: contract.address.toString(),
+    date: document.date,
+    id: document.id,
+    type: document.external ? 'added' : 'instantiated',
+  };
+}

--- a/src/ui/pages/Contract.tsx
+++ b/src/ui/pages/Contract.tsx
@@ -2,17 +2,16 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { BookOpenIcon, PlayIcon } from '@heroicons/react/outline';
 import { useLiveQuery } from 'dexie-react-hooks';
-import { InteractTab } from '../components/contract/Interact';
-import { MetadataTab } from '../components/contract/Metadata';
-import { CopyButton } from '../components/common/CopyButton';
-import { Loader } from '../components/common/Loader';
-import { Tabs } from '../components/common/Tabs';
-import { HeaderButtons } from '../components/common/HeaderButtons';
+import { ContractHeader } from './ContractHeader';
+import { InteractTab } from 'ui/components/contract/Interact';
+import { MetadataTab } from 'ui/components/contract/Metadata';
+import { Loader } from 'ui/components/common/Loader';
+import { Tabs } from 'ui/components/common/Tabs';
+import { HeaderButtons } from 'ui/components/common/HeaderButtons';
 import { PageFull } from 'ui/templates';
-import { displayDate, truncate } from 'helpers';
 import { useApi, useDatabase } from 'ui/contexts';
 import { ContractDocument, ContractPromise } from 'types';
 
@@ -41,15 +40,12 @@ export function Contract() {
   const navigate = useNavigate();
   const { api } = useApi();
   const { db } = useDatabase();
-
   const { address, activeTab = 'interact' } = useParams();
-
   const [contract, setContract] = useState<ContractPromise>();
   const [document, setDocument] = useState<ContractDocument>();
+  const [tabIndex, setTabIndex] = useState(TABS.findIndex(({ id }) => id === activeTab) || 1);
 
   if (!address) throw new Error('No address in url');
-
-  const [tabIndex, setTabIndex] = useState(TABS.findIndex(({ id }) => id === activeTab) || 1);
 
   useLiveQuery(async () => {
     if (!address) return;
@@ -65,7 +61,7 @@ export function Contract() {
     }
   }, [address]);
 
-  const projectName = contract?.abi.info.contract.name;
+  const projectName = contract?.abi.info.contract.name.toString();
 
   return (
     <Loader isLoading={!document} message="Loading contract...">
@@ -74,36 +70,11 @@ export function Contract() {
           accessory={<HeaderButtons contract={document} />}
           header={document?.name || projectName}
           help={
-            document.external ? (
-              <div>
-                You added this contract from{' '}
-                <div className="inline-flex items-center">
-                  <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
-                    {truncate(address, 4)}
-                  </span>
-                  <CopyButton className="ml-1" value={address} id="header-address" />
-                </div>{' '}
-                on {displayDate(document.date)}
-              </div>
-            ) : (
-              <div>
-                You instantiated this contract{' '}
-                <div className="inline-flex items-center">
-                  <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
-                    {truncate(address, 4)}
-                  </span>
-                  <CopyButton className="ml-1" value={address} id="header-address" />
-                </div>{' '}
-                from{' '}
-                <Link
-                  to={`/instantiate/${document.codeHash}`}
-                  className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded"
-                >
-                  {projectName}
-                </Link>{' '}
-                on {displayDate(document.date)}
-              </div>
-            )
+            <ContractHeader
+              type={document.external ? 'added' : 'instantiated'}
+              document={document}
+              name={projectName ?? ''}
+            />
           }
         >
           <Tabs index={tabIndex} setIndex={setTabIndex} tabs={TABS}>

--- a/src/ui/pages/Contract.tsx
+++ b/src/ui/pages/Contract.tsx
@@ -1,7 +1,7 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { BookOpenIcon, PlayIcon } from '@heroicons/react/outline';
 import { useLiveQuery } from 'dexie-react-hooks';
@@ -12,7 +12,7 @@ import { Loader } from '../components/common/Loader';
 import { Tabs } from '../components/common/Tabs';
 import { HeaderButtons } from '../components/common/HeaderButtons';
 import { PageFull } from 'ui/templates';
-import { checkOnChainCode, displayDate, truncate } from 'helpers';
+import { displayDate, truncate } from 'helpers';
 import { useApi, useDatabase } from 'ui/contexts';
 import { ContractDocument, ContractPromise } from 'types';
 
@@ -51,15 +51,6 @@ export function Contract() {
 
   const [tabIndex, setTabIndex] = useState(TABS.findIndex(({ id }) => id === activeTab) || 1);
 
-  const [isOnChain, setIsOnChain] = useState<boolean>(false);
-
-  useEffect(() => {
-    document &&
-      checkOnChainCode(api, document.codeHash || '')
-        .then(isOnChain => setIsOnChain(isOnChain))
-        .catch(console.error);
-  }, [api, document]);
-
   useLiveQuery(async () => {
     if (!address) return;
     setContract(undefined);
@@ -83,8 +74,7 @@ export function Contract() {
           accessory={<HeaderButtons contract={document} />}
           header={document?.name || projectName}
           help={
-            isOnChain &&
-            (document.external ? (
+            document.external ? (
               <div>
                 You added this contract from{' '}
                 <div className="inline-flex items-center">
@@ -113,7 +103,7 @@ export function Contract() {
                 </Link>{' '}
                 on {displayDate(document.date)}
               </div>
-            ))
+            )
           }
         >
           <Tabs index={tabIndex} setIndex={setTabIndex} tabs={TABS}>

--- a/src/ui/pages/Contract.tsx
+++ b/src/ui/pages/Contract.tsx
@@ -107,7 +107,7 @@ export function Contract() {
           }
         >
           <Tabs index={tabIndex} setIndex={setTabIndex} tabs={TABS}>
-            <MetadataTab />
+            <MetadataTab abi={contract.abi} id={document.id} />
             <InteractTab contract={contract} />
           </Tabs>
         </PageFull>

--- a/src/ui/pages/ContractHeader.tsx
+++ b/src/ui/pages/ContractHeader.tsx
@@ -1,0 +1,51 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { Link } from 'react-router-dom';
+import { CopyButton } from '../components/common/CopyButton';
+import { displayDate, truncate } from 'helpers';
+import { ContractDocument } from 'types';
+
+interface Props {
+  type: 'added' | 'instantiated';
+  document: ContractDocument;
+  name: string;
+}
+
+export function ContractHeader({ type, document, name }: Props) {
+  switch (type) {
+    case 'added':
+      return (
+        <div>
+          You added this contract from{' '}
+          <div className="inline-flex items-center">
+            <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
+              {truncate(document.address, 4)}
+            </span>
+            <CopyButton className="ml-1" value={document.address} id="header-address" />
+          </div>{' '}
+          on {displayDate(document.date)}
+        </div>
+      );
+    case 'instantiated':
+      return (
+        <div>
+          You instantiated this contract{' '}
+          <div className="inline-flex items-center">
+            <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
+              {truncate(document.address, 4)}
+            </span>
+            <CopyButton className="ml-1" value={document.address} id="header-address" />
+          </div>{' '}
+          from{' '}
+          <Link
+            to={`/instantiate/${document.codeHash}`}
+            className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded"
+          >
+            {name}
+          </Link>{' '}
+          on {displayDate(document.date)}
+        </div>
+      );
+  }
+}

--- a/src/ui/pages/ContractHeader.tsx
+++ b/src/ui/pages/ContractHeader.tsx
@@ -4,15 +4,13 @@
 import { Link } from 'react-router-dom';
 import { CopyButton } from '../components/common/CopyButton';
 import { displayDate, truncate } from 'helpers';
-import { ContractDocument } from 'types';
+import { UIContract } from 'types';
 
 interface Props {
-  type: 'added' | 'instantiated';
-  document: ContractDocument;
-  name: string;
+  document: UIContract;
 }
 
-export function ContractHeader({ type, document, name }: Props) {
+export function ContractHeader({ document: { name, type, address, date, codeHash } }: Props) {
   switch (type) {
     case 'added':
       return (
@@ -20,11 +18,11 @@ export function ContractHeader({ type, document, name }: Props) {
           You added this contract from{' '}
           <div className="inline-flex items-center">
             <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
-              {truncate(document.address, 4)}
+              {truncate(address, 4)}
             </span>
-            <CopyButton className="ml-1" value={document.address} id="header-address" />
+            <CopyButton className="ml-1" value={address} id="header-address" />
           </div>{' '}
-          on {displayDate(document.date)}
+          on {displayDate(date)}
         </div>
       );
     case 'instantiated':
@@ -33,18 +31,18 @@ export function ContractHeader({ type, document, name }: Props) {
           You instantiated this contract{' '}
           <div className="inline-flex items-center">
             <span className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded">
-              {truncate(document.address, 4)}
+              {truncate(address, 4)}
             </span>
-            <CopyButton className="ml-1" value={document.address} id="header-address" />
+            <CopyButton className="ml-1" value={address} id="header-address" />
           </div>{' '}
           from{' '}
           <Link
-            to={`/instantiate/${document.codeHash}`}
+            to={`/instantiate/${codeHash}`}
             className="inline-block relative bg-blue-500 text-blue-400 bg-opacity-20 text-xs px-1.5 py-1 font-mono rounded"
           >
             {name}
           </Link>{' '}
-          on {displayDate(document.date)}
+          on {displayDate(date)}
         </div>
       );
   }


### PR DESCRIPTION
IndexDb can't store the `ContractPromise` so it needs to be created after retrieving the contract from storage. Refactored the code so that a single interface is used in the UI.
Improved readability by extracting some code and removing unnecessary db calls.
More information is now un-hidden from the user when the contract isn't on-chain anymore. 