### PR TITLE
415 do not overwrite user defined contract name on upload of metadata

### DIFF
--- a/src/types/ui/util.ts
+++ b/src/types/ui/util.ts
@@ -21,6 +21,7 @@ export type SimpleSpread<L, R> = R & Pick<L, Exclude<keyof L, keyof R>>;
 export type ValidateFn<T> = (_: OrFalsy<T>) => Validation;
 
 export interface Validation {
+  isEmpty?: boolean;
   isError?: boolean;
   isSuccess?: boolean;
   isTouched?: boolean;

--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -35,11 +35,14 @@ export function Step1() {
     ...metadataValidation
   } = useMetadataField();
 
-  useEffect((): void => {
-    if (metadataValidation.name) {
-      setName(metadataValidation.name);
-    }
-  }, [metadataValidation.name, setName]);
+  useEffect(
+    function updateNameFromMetadata(): void {
+      if (metadataValidation.name && nameValidation.isEmpty) {
+        setName(metadataValidation.name);
+      }
+    },
+    [metadataValidation.name, nameValidation.isEmpty, setName]
+  );
 
   useEffect((): void => {
     if (!accounts || accounts.length === 0) return;

--- a/src/ui/hooks/useFormField.ts
+++ b/src/ui/hooks/useFormField.ts
@@ -13,6 +13,7 @@ export function useFormField<T>(
   const [value, setValue] = useState<T>(defaultValue);
   const [validation, setValidation] = useState<Omit<Validation, 'isError'>>(validate(value));
   const isTouched = useRef(false);
+  const isEmpty = useRef(isUndefined(defaultValue) || isNull(defaultValue) || defaultValue === '');
 
   const isError = useMemo(() => {
     if (!isTouched.current) {
@@ -28,6 +29,9 @@ export function useFormField<T>(
         setValue(value);
         setValidation(validate(value));
         isTouched.current = true;
+        isEmpty.current = false;
+      } else {
+        isEmpty.current = true;
       }
     },
     [validate]
@@ -35,13 +39,14 @@ export function useFormField<T>(
 
   return useMemo(
     () => ({
-      value,
-      onChange,
-      isValid: validation.isValid,
+      isEmpty: isEmpty.current,
+      isError,
       isTouched: isTouched.current,
+      isValid: validation.isValid,
       isWarning: validation.isWarning || false,
       message: validation.message,
-      isError,
+      onChange,
+      value,
     }),
     [value, onChange, isError, validation.isValid, validation.isWarning, validation.message]
   );

--- a/src/ui/hooks/useNonEmptyString.ts
+++ b/src/ui/hooks/useNonEmptyString.ts
@@ -7,7 +7,7 @@ import type { ValidFormField, Validation } from 'types';
 
 export function useNonEmptyString(initialValue = ''): ValidFormField<string> {
   const validate = useCallback((value?: string | null): Validation => {
-    if (!value || value.length === 0) {
+    if (!value || value.trim().length === 0) {
       return { isValid: false, message: 'Value cannot be empty' };
     }
 

--- a/src/ui/pages/Instantiate.tsx
+++ b/src/ui/pages/Instantiate.tsx
@@ -21,7 +21,7 @@ export function Instantiate() {
             <p className="dark:text-gray-400 text-gray-500 text-sm">
               {codeHashUrlParam ? (
                 <>
-                  You can upload and instantate new contract code{' '}
+                  You can upload and instantiate new contract code{' '}
                   <Link to="/instantiate" className="text-blue-500">
                     here
                   </Link>


### PR DESCRIPTION
As described in #415, this PR prevents overwriting the contracts name from the metadata if a name is already provided.