### PR TITLE
feat: remove all contracts button

### DIFF
--- a/src/ui/components/common/HeaderButtons.tsx
+++ b/src/ui/components/common/HeaderButtons.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 import { ArrowCircleRightIcon, TrashIcon } from '@heroicons/react/outline';
 import { Link, useNavigate } from 'react-router-dom';
-import { ConfirmModal } from 'ui/components/modal';
+import { ForgetContractModal } from 'ui/components/modal';
 import { useApi, useDatabase } from 'ui/contexts';
 import { getContractInfo, truncate } from 'helpers';
 import type { UIContract } from 'types';
@@ -63,7 +63,7 @@ export function HeaderButtons({ contract: { address, codeHash } }: Props) {
           <TrashIcon className="w-4 dark:text-gray-500 mr-1 justify-self-end" />
         </button>
       </div>
-      <ConfirmModal setIsOpen={setIsOpen} isOpen={isOpen} confirm={forgetContract} />
+      <ForgetContractModal setIsOpen={setIsOpen} isOpen={isOpen} confirm={forgetContract} />
     </div>
   );
 }

--- a/src/ui/components/homepage/Contracts.tsx
+++ b/src/ui/components/homepage/Contracts.tsx
@@ -40,7 +40,7 @@ export function Contracts(): React.ReactElement | null {
             return <ContractRow contract={contract} key={`contract-${contract.address}`} />;
           })}
         </div>
-        <div className="grid pt-2 justify-items-end">
+        <div className="grid pt-4 justify-items-end">
           <button
             title="Forget All Contracts"
             className="flex font-semibold items-center dark:text-gray-300 dark:bg-elevation-1 dark:hover:bg-elevation-2 dark:border-gray-700 text-gray-600 hover:text-gray-400 border h-full p-3 rounded"

--- a/src/ui/components/homepage/Contracts.tsx
+++ b/src/ui/components/homepage/Contracts.tsx
@@ -1,15 +1,19 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { FolderOpenIcon } from '@heroicons/react/outline';
+import { FolderOpenIcon, TrashIcon } from '@heroicons/react/outline';
+import { useCallback, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ContractRow } from '../contract/ContractRow';
+import { ForgetAllContractsModal } from 'ui/components/modal';
 import { useDatabase } from 'ui/contexts';
 import { useDbQuery } from 'ui/hooks';
 
 export function Contracts(): React.ReactElement | null {
   const { db } = useDatabase();
+  const [isOpen, setIsOpen] = useState(false);
   const [contracts, isLoading] = useDbQuery(() => db.contracts.toArray(), [db]);
+  const forgetAllContracts = useCallback(() => db.contracts.clear(), [db]);
 
   if (isLoading || !contracts) {
     return null;
@@ -28,10 +32,25 @@ export function Contracts(): React.ReactElement | null {
   }
 
   return (
-    <div className="border border-collapse overflow-hidden dark:border-gray-700 border-gray-200 rounded w-auto">
-      {contracts?.map(contract => {
-        return <ContractRow contract={contract} key={`contract-${contract.address}`} />;
-      })}
-    </div>
+    <>
+      <ForgetAllContractsModal isOpen={isOpen} setIsOpen={setIsOpen} confirm={forgetAllContracts} />
+      <div>
+        <div className="border border-collapse overflow-hidden dark:border-gray-700 border-gray-200 rounded w-auto">
+          {contracts?.map(contract => {
+            return <ContractRow contract={contract} key={`contract-${contract.address}`} />;
+          })}
+        </div>
+        <div className="grid pt-2 justify-items-end">
+          <button
+            title="Forget All Contracts"
+            className="flex font-semibold items-center dark:text-gray-300 dark:bg-elevation-1 dark:hover:bg-elevation-2 dark:border-gray-700 text-gray-600 hover:text-gray-400 border h-full p-3 rounded"
+            onClick={() => setIsOpen(true)}
+          >
+            <p className="mr-2 text-xs">Forget All Contracts</p>
+            <TrashIcon className="w-4 dark:text-gray-500 mr-1 justify-self-end" />
+          </button>
+        </div>
+      </div>
+    </>
   );
 }

--- a/src/ui/components/modal/ForgetAllContractsModal.tsx
+++ b/src/ui/components/modal/ForgetAllContractsModal.tsx
@@ -1,0 +1,45 @@
+// Copyright 2022 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { TrashIcon } from '@heroicons/react/outline';
+import { useCallback, useState } from 'react';
+import type { ModalProps } from './ModalBase';
+import { ModalBase as Modal } from './ModalBase';
+
+interface Props extends ModalProps {
+  confirm: () => Promise<void>;
+}
+
+export const ForgetAllContractsModal = ({ isOpen, setIsOpen, confirm }: Omit<Props, 'title'>) => {
+  const [isBusy, setIsBusy] = useState(false);
+  const onConfirm = useCallback(() => {
+    setIsBusy(true);
+    confirm()
+      .then(() => setIsOpen(false))
+      .catch(console.error)
+      .finally(() => setIsBusy(false));
+  }, [confirm, setIsOpen]);
+
+  return (
+    <Modal isOpen={isOpen} setIsOpen={setIsOpen} title="Forget All Contracts">
+      <div className="py-8 dark:text-gray-500 text-gray-400 text-sm">
+        <p className="mb-2">
+          You will remove the metadata for all contract instances from browser storage.
+        </p>
+        <p className="mb-8">
+          This operation has no on-chain consequences. The forget operation only removes references
+          to these contracts from your browser.
+        </p>
+        <button
+          title="Forget contract"
+          className="flex font-semibold items-center dark:text-gray-300 justify-self-end dark:bg-elevation-1 dark:hover:bg-elevation-2 dark:border-gray-700 text-gray-600 hover:text-gray-400 border h-full p-3 rounded"
+          onClick={onConfirm}
+          disabled={isBusy}
+        >
+          <p className="mr-2 text-xs">Forget All Contracts</p>
+          <TrashIcon className="w-4 dark:text-gray-500 mr-1 justify-self-end" />
+        </button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/ui/components/modal/ForgetContractModal.tsx
+++ b/src/ui/components/modal/ForgetContractModal.tsx
@@ -9,7 +9,7 @@ interface Props extends ModalProps {
   confirm: () => void;
 }
 
-export const ConfirmModal = ({ isOpen, setIsOpen, confirm }: Omit<Props, 'title'>) => {
+export const ForgetContractModal = ({ isOpen, setIsOpen, confirm }: Omit<Props, 'title'>) => {
   return (
     <Modal isOpen={isOpen} setIsOpen={setIsOpen} title="Confirm action">
       <div className="py-8 dark:text-gray-500 text-gray-400 text-sm">
@@ -20,7 +20,7 @@ export const ConfirmModal = ({ isOpen, setIsOpen, confirm }: Omit<Props, 'title'
         </p>
         <button
           title="Forget contract"
-          className="flex font-semibold items-center dark:text-gray-300 dark:bg-elevation-1 dark:hover:bg-elevation-2 dark:border-gray-700 text-gray-600 hover:text-gray-400 border h-full p-3 rounded"
+          className="font-semibold items-center dark:text-gray-300 dark:bg-elevation-1 dark:hover:bg-elevation-2 dark:border-gray-700 text-gray-600 hover:text-gray-400 border h-full p-3 rounded"
           onClick={() => confirm()}
         >
           <p className="mr-2 text-xs">Forget contract</p>

--- a/src/ui/components/modal/index.ts
+++ b/src/ui/components/modal/index.ts
@@ -1,5 +1,6 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+export * from './ForgetAllContractsModal';
+export * from './ForgetContractModal';
 export * from './HelpModal';
-export * from './ConfirmModal';


### PR DESCRIPTION
Adds new "Forget All Contracts" button, to easily remove all known contracts from the browsers LocalStorage as described in #414. 

It's only available in in the `Contracts` overview to keep the sidebar clean.

<img width="862" alt="Screenshot 2023-03-13 at 13 59 01" src="https://user-images.githubusercontent.com/839848/224709544-52e49ce4-2b20-4aa0-bf8a-e340426a0f20.png">
