### PR TITLE
feat: allow users to copy the code hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-router": "^6.8.2",
     "react-router-dom": "^6.8.2",
     "react-select": "^5.7.0",
-    "react-tooltip": "^4.5.0",
+    "react-tooltip": "^5.10.0",
     "remark-gfm": "^3.0.1",
     "styled-components": "^5.3.8",
     "tailwind-merge": "^1.10.0",

--- a/src/ui/components/account/Identicon.tsx
+++ b/src/ui/components/account/Identicon.tsx
@@ -1,11 +1,11 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import ReactTooltip from 'react-tooltip';
-import copy from 'copy-to-clipboard';
-import type { Circle } from '@polkadot/ui-shared/icons/types';
-import React, { useCallback, useRef } from 'react';
 import { polkadotIcon } from '@polkadot/ui-shared';
+import type { Circle } from '@polkadot/ui-shared/icons/types';
+import copy from 'copy-to-clipboard';
+import React, { useCallback } from 'react';
+import { Tooltip } from 'react-tooltip';
 import { Button } from '../common';
 import { classes } from 'helpers';
 
@@ -26,13 +26,9 @@ function IdenticonBase({
   size,
   style,
 }: Props): React.ReactElement<Props> | null {
-  const ref = useRef<HTMLButtonElement>(null);
-
   const onClick = useCallback(() => {
     if (value) {
       copy(value);
-
-      ref.current && ReactTooltip.show(ref.current);
     }
   }, [value]);
 
@@ -43,9 +39,8 @@ function IdenticonBase({
       <>
         <Button
           data-tip
-          data-for={tooltipId}
+          data-tooltip-id={tooltipId}
           onClick={onClick}
-          ref={ref}
           variant="plain"
           data-cy="identicon"
         >
@@ -61,15 +56,9 @@ function IdenticonBase({
             {polkadotIcon(value || '', { isAlternative }).map(renderCircle)}
           </svg>
         </Button>
-        <ReactTooltip
-          afterShow={() => {
-            setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 1000);
-          }}
-          id={tooltipId}
-          event="none"
-        >
+        <Tooltip openOnClick id={tooltipId}>
           Copied to clipboard
-        </ReactTooltip>
+        </Tooltip>
       </>
     );
   } catch (e) {

--- a/src/ui/components/common/CopyButton.tsx
+++ b/src/ui/components/common/CopyButton.tsx
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import copy from 'copy-to-clipboard';
-import React, { useCallback, useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { DocumentDuplicateIcon } from '@heroicons/react/outline';
-import ReactTooltip from 'react-tooltip';
+import { Tooltip } from 'react-tooltip';
 import { Button } from './Button';
 import { classes } from 'helpers';
 
@@ -16,18 +16,22 @@ interface Props extends React.HTMLAttributes<unknown> {
 
 export function CopyButton({ className, iconClassName, value, id }: Props) {
   const ref = useRef<HTMLButtonElement>(null);
+  const [showTooltip, setShowTooltip] = useState(false);
   const onClick = useCallback((): void => {
     copy(value);
 
-    ref.current && ReactTooltip.show(ref.current);
+    setShowTooltip(true);
+    setTimeout(() => {
+      setShowTooltip(false);
+    }, 1500);
   }, [value]);
 
   return (
     <>
       <Button
         className={classes('', className)}
-        data-for={id}
-        data-tip
+        data-tooltip-id={id}
+        data-tooltip-content="Copied to clipboard"
         onClick={onClick}
         ref={ref}
         variant="plain"
@@ -36,13 +40,7 @@ export function CopyButton({ className, iconClassName, value, id }: Props) {
           className={classes('w-4 h-4 hover:text-gray-600 dark:hover:text-gray-300', iconClassName)}
         />
       </Button>
-      <ReactTooltip
-        afterShow={() => setTimeout(() => ref.current && ReactTooltip.hide(ref.current), 300)}
-        id={id}
-        event="none"
-      >
-        Copied to clipboard
-      </ReactTooltip>
+      <Tooltip id={id} place="top" isOpen={showTooltip} />
     </>
   );
 }

--- a/src/ui/components/common/CopyButton.tsx
+++ b/src/ui/components/common/CopyButton.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import copy from 'copy-to-clipboard';
-import { useCallback, useRef, useState } from 'react';
+import { MouseEventHandler, useCallback, useRef, useState } from 'react';
 import { DocumentDuplicateIcon } from '@heroicons/react/outline';
 import { Tooltip } from 'react-tooltip';
 import { Button } from './Button';
@@ -17,14 +17,19 @@ interface Props extends React.HTMLAttributes<unknown> {
 export function CopyButton({ className, iconClassName, value, id }: Props) {
   const ref = useRef<HTMLButtonElement>(null);
   const [showTooltip, setShowTooltip] = useState(false);
-  const onClick = useCallback((): void => {
-    copy(value);
+  const onClick: MouseEventHandler = useCallback(
+    (event): void => {
+      event.stopPropagation();
 
-    setShowTooltip(true);
-    setTimeout(() => {
-      setShowTooltip(false);
-    }, 1500);
-  }, [value]);
+      copy(value);
+
+      setShowTooltip(true);
+      setTimeout(() => {
+        setShowTooltip(false);
+      }, 1000);
+    },
+    [value]
+  );
 
   return (
     <>

--- a/src/ui/components/common/CopyButton.tsx
+++ b/src/ui/components/common/CopyButton.tsx
@@ -20,9 +20,7 @@ export function CopyButton({ className, iconClassName, value, id }: Props) {
   const onClick: MouseEventHandler = useCallback(
     (event): void => {
       event.stopPropagation();
-
       copy(value);
-
       setShowTooltip(true);
       setTimeout(() => {
         setShowTooltip(false);

--- a/src/ui/components/form/FormField.tsx
+++ b/src/ui/components/form/FormField.tsx
@@ -7,7 +7,7 @@ import {
   CheckCircleIcon,
 } from '@heroicons/react/outline';
 import { useMemo } from 'react';
-import ReactTooltip from 'react-tooltip';
+import { Tooltip } from 'react-tooltip';
 import type { Validation } from 'types';
 import { classes } from 'helpers';
 
@@ -56,8 +56,8 @@ export function FormField({
           {label}
           {help && (
             <>
-              <InformationCircleIcon data-tip data-for={`formFieldHelp-${id}`} />
-              <ReactTooltip id={`formFieldHelp-${id}`}>{help}</ReactTooltip>
+              <InformationCircleIcon data-tip data-tooltip-id={`formFieldHelp-${id}`} />
+              <Tooltip id={`formFieldHelp-${id}`}>{help}</Tooltip>
             </>
           )}
         </label>

--- a/src/ui/components/instantiate/CodeHash.tsx
+++ b/src/ui/components/instantiate/CodeHash.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import { SimpleSpread, VoidFn } from 'types';
 import { useApi, useDatabase } from 'ui/contexts';
 import { checkOnChainCode, classes, truncate } from 'helpers';
+import { CopyButton } from '../common/CopyButton';
 
 type Props = SimpleSpread<
   React.HTMLAttributes<HTMLButtonElement>,
@@ -51,7 +52,10 @@ export function CodeHash({ className, codeHash, error, name, isError, isSuccess,
           {!isError ? name || 'On-chain Code Hash' : 'Invalid Code Hash'}
         </div>
         {codeHash && !isError && (
-          <div className="dark:text-gray-500 text-sm">Code hash: {truncate(codeHash)}</div>
+          <div className="flex gap-1 dark:text-gray-500 text-sm">
+            Code hash: {truncate(codeHash)}
+            <CopyButton id={codeHash} value={codeHash} />
+          </div>
         )}
         {isError && <div className="dark:text-gray-500 text-sm">{error}</div>}
       </div>

--- a/src/ui/index.tsx
+++ b/src/ui/index.tsx
@@ -5,6 +5,7 @@ import { Buffer } from 'buffer';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import App from 'ui/components/App';
+import 'react-tooltip/dist/react-tooltip.css';
 import './styles/main.css';
 import '@polkadot/api-augment';
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,6 +886,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@floating-ui/core@npm:^1.2.2":
+  version: 1.2.3
+  resolution: "@floating-ui/core@npm:1.2.3"
+  checksum: dbaff1b454314facc62d3e70955e7ce4f8ccd8530d08b8c508df588ea775674d3d4048de6c1424074f0659f7dc88bbda8ff7a5c8e17e86daa5fad34e40c7f7d3
+  languageName: node
+  linkType: hard
+
+"@floating-ui/dom@npm:1.2.3":
+  version: 1.2.3
+  resolution: "@floating-ui/dom@npm:1.2.3"
+  dependencies:
+    "@floating-ui/core": ^1.2.2
+  checksum: b2428e1fda01d5cba59960bb8c04d7a5f2400200855f206267589533a67303a62fbdf85dc7747fe83c21bb15f4eda67feaaf51ef4a41bb132fd2b785612f1bb4
+  languageName: node
+  linkType: hard
+
 "@floating-ui/dom@npm:^1.0.1":
   version: 1.0.12
   resolution: "@floating-ui/dom@npm:1.0.12"
@@ -2840,6 +2856,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"classnames@npm:^2.3.2":
+  version: 2.3.2
+  resolution: "classnames@npm:2.3.2"
+  checksum: 2c62199789618d95545c872787137262e741f9db13328e216b093eea91c85ef2bfb152c1f9e63027204e2559a006a92eb74147d46c800a9f96297ae1d9f96f4e
+  languageName: node
+  linkType: hard
+
 "clean-stack@npm:^2.0.0":
   version: 2.2.0
   resolution: "clean-stack@npm:2.2.0"
@@ -3087,7 +3110,7 @@ __metadata:
     react-router: ^6.8.2
     react-router-dom: ^6.8.2
     react-select: ^5.7.0
-    react-tooltip: ^4.5.0
+    react-tooltip: ^5.10.0
     remark-gfm: ^3.0.1
     source-map-support: ^0.5.21
     styled-components: ^5.3.8
@@ -7476,16 +7499,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-tooltip@npm:^4.5.0":
-  version: 4.5.1
-  resolution: "react-tooltip@npm:4.5.1"
+"react-tooltip@npm:^5.10.0":
+  version: 5.10.0
+  resolution: "react-tooltip@npm:5.10.0"
   dependencies:
-    prop-types: ^15.8.1
-    uuid: ^7.0.3
+    "@floating-ui/dom": 1.2.3
+    classnames: ^2.3.2
   peerDependencies:
-    react: ">=16.0.0"
-    react-dom: ">=16.0.0"
-  checksum: bb2065b6aec5d860627e1459cd193889a236093c484f32a021b7b3c8c36c2144d1077932b5d74bc0262f1e24a3e0fd8251df2107c348a913a9b236467ed2185d
+    react: ">=16.14.0"
+    react-dom: ">=16.14.0"
+  checksum: b1fdfa27cecc632afb418e1deb2f3184f69ca61e007bae28b43d91ea45857cf640f3754ba6e8148a35fc6f6ed0e0572d36a4f79e0865d0ea6940b9ddaaeaede9
   languageName: node
   linkType: hard
 
@@ -8799,15 +8822,6 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^7.0.3":
-  version: 7.0.3
-  resolution: "uuid@npm:7.0.3"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: f5b7b5cc28accac68d5c083fd51cca64896639ebd4cca88c6cfb363801aaa83aa439c86dfc8446ea250a7a98d17afd2ad9e88d9d4958c79a412eccb93bae29de
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

The hash of the deployed contract can now easily be copied from the contract page  itself.

<img width="852" alt="Screenshot 2023-03-13 at 14 45 48" src="https://user-images.githubusercontent.com/839848/224720316-94c5a679-c6bb-4f42-9950-f487c4d11e83.png">

I've took the liberty to upgrade the used `react-tooltip` library from v4 to v5, which fixes a displaying issue present with v4.

### before
<img width="749" alt="before" src="https://user-images.githubusercontent.com/839848/224720737-c9d65de6-faa5-44ac-9a98-9b16ac1c68b3.png">

### after
<img width="702" alt="Screenshot 2023-03-13 at 14 48 08" src="https://user-images.githubusercontent.com/839848/224720940-5b986765-a507-4598-8a76-c2847503bcac.png">



