### PR TITLE
feat: add more testnets to dropdown

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -4,13 +4,78 @@
 import BN from 'bn.js';
 import type { ApiState } from 'types';
 
-export enum RPC {
-  LOCAL = 'ws://127.0.0.1:9944',
-  CONTRACTS = 'wss://rococo-contracts-rpc.polkadot.io',
-  SHIBUYA = 'wss://rpc.shibuya.astar.network',
-  SHIDEN = 'wss://rpc.shiden.astar.network',
-  ALEPHZEROTESTNET = 'wss://ws.test.azero.dev',
-}
+export const ROCOCO_CONTRACTS = {
+  relay: 'Rococo',
+  name: 'Rococo Contracts',
+  rpc: 'wss://rococo-contracts-rpc.polkadot.io',
+};
+
+export const LOCAL = {
+  relay: undefined,
+  name: 'Local Node',
+  rpc: 'ws://127.0.0.1:9944',
+};
+
+// https://docs.peaq.network/networks-overview
+const PEAQ_AGUNG = {
+  relay: 'Rococo',
+  name: 'Peaq Agung',
+  rpc: 'wss://wss.agung.peaq.network',
+};
+
+const PHALA_TESTNET = {
+  relay: undefined,
+  name: 'Phala PoC-5',
+  rpc: 'wss://poc5.phala.network',
+};
+
+// https://docs.astar.network/docs/build/environment/endpoints
+const ASTAR_SHIDEN = {
+  relay: 'Kusama',
+  name: 'Astar Shiden',
+  rpc: 'wss://rpc.shiden.astar.network',
+};
+
+// https://docs.astar.network/docs/build/environment/endpoints
+const ASTAR_SHIBUYA = {
+  relay: 'Tokyo',
+  name: 'Astar Shibuya',
+  rpc: 'wss://rpc.shibuya.astar.network',
+};
+
+const ALEPH_ZERO_TESTNET = {
+  relay: undefined,
+  name: 'Aleph Zero Testnet',
+  rpc: 'wss://ws.test.azero.dev',
+};
+
+// https://docs.t3rn.io/collator/testnet/testnet-collator
+const T3RN_T0RN = {
+  relay: undefined,
+  name: 'T3RN T0RN',
+  rpc: 'wss://ws.t0rn.io',
+};
+
+// https://pendulum.gitbook.io/pendulum-docs/build/build-environment/foucoco-testnet
+const PENDULUM_TESTNET = {
+  relay: 'Rococo',
+  name: 'Pendulum Testnet',
+  rpc: 'wss://rpc-foucoco.pendulumchain.tech',
+};
+
+export const TESTNETS = [
+  ROCOCO_CONTRACTS,
+  PEAQ_AGUNG,
+  PHALA_TESTNET,
+  ASTAR_SHIBUYA,
+  ALEPH_ZERO_TESTNET,
+  T3RN_T0RN,
+  PENDULUM_TESTNET,
+  LOCAL,
+];
+
+export const MAINNETS = [ASTAR_SHIDEN];
+
 export const DEFAULT_DECIMALS = 12;
 
 export const MAX_CALL_WEIGHT = new BN(2_000_000_000_000);
@@ -24,7 +89,7 @@ export const NULL_CHAIN_PROPERTIES = {
 
 export const INIT_STATE: ApiState = {
   ...NULL_CHAIN_PROPERTIES,
-  endpoint: RPC.LOCAL,
+  endpoint: LOCAL.rpc,
   keyringStatus: null,
   error: null,
   status: 'CONNECT_INIT',

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -26,7 +26,7 @@ const PEAQ_AGUNG = {
 const PHALA_TESTNET = {
   relay: undefined,
   name: 'Phala PoC-5',
-  rpc: 'wss://poc5.phala.network',
+  rpc: 'wss://poc5.phala.network/ws',
 };
 
 // https://docs.astar.network/docs/build/environment/endpoints

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,7 +6,7 @@ import type { ApiState } from 'types';
 
 export const ROCOCO_CONTRACTS = {
   relay: 'Rococo',
-  name: 'Rococo Contracts',
+  name: 'Contracts (Rococo)',
   rpc: 'wss://rococo-contracts-rpc.polkadot.io',
 };
 

--- a/src/ui/components/common/ConnectionError.tsx
+++ b/src/ui/components/common/ConnectionError.tsx
@@ -4,7 +4,7 @@
 import { useNavigate } from 'react-router-dom';
 import { Error } from './Error';
 import { useApi } from 'ui/contexts';
-import { RPC } from 'src/constants';
+import { ROCOCO_CONTRACTS, LOCAL } from 'src/constants';
 
 function ContractsNodeHelp() {
   const navigate = useNavigate();
@@ -33,7 +33,7 @@ function ContractsNodeHelp() {
           href="#"
           className="whitespace-nowrap"
           onClick={() => {
-            navigate(`/?rpc=${RPC.CONTRACTS}`);
+            navigate(`/?rpc=${ROCOCO_CONTRACTS.rpc}`);
           }}
         >
           Contracts parachain on Rococo.
@@ -49,7 +49,7 @@ export function ConnectionError() {
   return (
     <Error>
       <div>Could not connect to {endpoint}</div>
-      {endpoint === RPC.LOCAL && <ContractsNodeHelp />}
+      {endpoint === LOCAL.rpc && <ContractsNodeHelp />}
     </Error>
   );
 }

--- a/src/ui/components/sidebar/NetworkAndUser.tsx
+++ b/src/ui/components/sidebar/NetworkAndUser.tsx
@@ -3,36 +3,37 @@
 
 import { useNavigate } from 'react-router';
 import { Dropdown } from '../common/Dropdown';
-import { RPC } from '../../../constants';
+import { TESTNETS, MAINNETS } from '../../../constants';
 import { useApi } from 'ui/contexts';
 import { classes } from 'helpers';
 
-const options = [
+const testnetOptions = TESTNETS.map(network => ({
+  label: network.name,
+  value: network.rpc,
+}));
+
+const mainnetOptions = MAINNETS.map(network => ({
+  label: network.name,
+  value: network.rpc,
+}));
+
+const allOptions = [...testnetOptions, ...mainnetOptions];
+
+const dropdownOptions = [
   {
-    label: 'Contracts (Rococo)',
-    value: RPC.CONTRACTS,
+    label: 'Live Networks',
+    options: mainnetOptions,
   },
   {
-    label: 'Shibuya',
-    value: RPC.SHIBUYA,
-  },
-  {
-    label: 'Shiden',
-    value: RPC.SHIDEN,
-  },
-  {
-    label: 'Aleph Zero Testnet',
-    value: RPC.ALEPHZEROTESTNET,
-  },
-  {
-    label: 'Local Node',
-    value: RPC.LOCAL,
+    label: 'Test Networks',
+    options: testnetOptions,
   },
 ];
 
 export function NetworkAndUser() {
   const { endpoint, status } = useApi();
   const navigate = useNavigate();
+  console.log({ endpoint });
 
   return (
     <div className="network-and-user">
@@ -46,8 +47,8 @@ export function NetworkAndUser() {
         onChange={e => {
           navigate(`/?rpc=${e}`);
         }}
-        options={options}
-        value={options.find(o => o.value === endpoint)?.value || RPC.CONTRACTS}
+        options={dropdownOptions}
+        value={allOptions.find(o => o.value === endpoint)?.value || allOptions[0].value}
       />
     </div>
   );

--- a/src/ui/contexts/ApiContext.tsx
+++ b/src/ui/contexts/ApiContext.tsx
@@ -6,7 +6,7 @@ import { useSearchParams } from 'react-router-dom';
 import { web3Accounts, web3Enable, web3EnablePromise } from '@polkadot/extension-dapp';
 import { WsProvider } from '@polkadot/api';
 import { keyring } from '@polkadot/ui-keyring';
-import { RPC } from '../../constants';
+import { ROCOCO_CONTRACTS } from '../../constants';
 import { ApiPromise, ApiState, ChainProperties, Account, Status, WeightV2 } from 'types';
 import { isValidWsUrl, isKeyringLoaded, getChainProperties } from 'helpers';
 import { useLocalStorage } from 'ui/hooks/useLocalStorage';
@@ -19,7 +19,7 @@ export const ApiContextProvider = ({ children }: React.PropsWithChildren<Partial
   const rpcUrl = searchParams.get('rpc');
   const [preferredEndpoint, setPreferredEndpoint] = useLocalStorage<string>(
     'contractsUiPreferredEndpoint',
-    RPC.CONTRACTS
+    ROCOCO_CONTRACTS.rpc
   );
   const [api, setApi] = useState({} as ApiPromise);
   const [endpoint, setEndpoint] = useState(preferredEndpoint);


### PR DESCRIPTION
adds all `awesome ink` listed chains:
https://github.com/paritytech/awesome-ink#-networks-where-you-can-deploy-ink-contracts

Yes it's a bit messy, it seems there is no single good resource to get all information about parachains to use in a software project yet. It's cumbersome to maintain it this way and quite a hassle collection this information from the individual docs.

![demo](https://user-images.githubusercontent.com/839848/224991090-35380ffb-76ce-4307-91ca-00208151b202.gif)
