### PR TITLE
fix: allow scroll if page content overflows vertically.

### DIFF
--- a/src/ui/templates/Page.tsx
+++ b/src/ui/templates/Page.tsx
@@ -11,15 +11,15 @@ interface PageProps extends HTMLAttributes<HTMLDivElement> {
 export function Page({ header, help, children }: PageProps): React.ReactElement<PageProps> {
   return (
     <>
-      <div className="w-full mx-auto">
-        <div className="grid md:grid-cols-12 h-full gap-5 px-5 py-3 m-2">
+      <div className="w-full mx-auto overflow-y-auto">
+        <div className="grid md:grid-cols-12 gap-5 px-5 py-3 m-2">
           <main className="md:col-span-8 p-4">
             <div className="space-y-1 border-b pb-6 dark:border-gray-800 border-gray-200">
               <h1 className="text-2.5xl font-semibold dark:text-white text-gray-700">{header}</h1>
               <p className="dark:text-gray-400 text-gray-500 text-sm">{help}</p>
             </div>
-            <div className="flex flex-col py-4 h-full">
-              <div className="-my-2 h-full overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="flex flex-col py-4">
+              <div className="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
                 <div className="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8 mt-4">
                   <>{children}</>
                 </div>


### PR DESCRIPTION
Described initially in #290.

Enables scrolling if content overflows vertically. Removes some h-full as it's making the content overflow with white space showing the scrollbar unnecessarily.

![demo](https://user-images.githubusercontent.com/839848/226326756-048d4c51-c6e7-44c4-bbd4-e9143f4973be.gif)
