### PR TITLE
fix: display text inputs for `Bytes`

### DIFF
--- a/src/helpers/initValue.ts
+++ b/src/helpers/initValue.ts
@@ -78,9 +78,8 @@ export function getInitValue(registry: Registry, accounts: Account[], def: TypeD
     case 'bool':
       return false;
 
-    // TODO: refactor InputBytes to accept strings
-    // case 'Bytes':
-    //   return '0x0000';
+    case 'Bytes':
+      return undefined;
 
     case 'String':
     case 'Text':

--- a/src/helpers/initValue.ts
+++ b/src/helpers/initValue.ts
@@ -78,8 +78,9 @@ export function getInitValue(registry: Registry, accounts: Account[], def: TypeD
     case 'bool':
       return false;
 
-    case 'Bytes':
-      return '0x0000';
+    // TODO: refactor InputBytes to accept strings
+    // case 'Bytes':
+    //   return '0x0000';
 
     case 'String':
     case 'Text':

--- a/src/ui/components/form/findComponent.tsx
+++ b/src/ui/components/form/findComponent.tsx
@@ -13,7 +13,6 @@ import { Struct } from './Struct';
 import { SubForm } from './SubForm';
 import { Tuple } from './Tuple';
 import { InputBn } from './InputBn';
-import { InputBytes } from './InputBytes';
 import { ArgComponentProps, Registry, TypeDef, TypeDefInfo } from 'types';
 
 function subComponents(
@@ -110,10 +109,10 @@ export function findComponent(
       </SubForm>
     );
   }
-
-  if (type.type.startsWith('Bytes')) {
-    return (props: ArgComponentProps<Uint8Array>) => <InputBytes {...props} />;
-  }
+  // TODO: refactor InputBytes to accept strings
+  // if (type.type.startsWith('Bytes')) {
+  //   return (props: ArgComponentProps<Uint8Array>) => <InputBytes {...props} />;
+  // }
 
   switch (type.type) {
     case 'AccountId':


### PR DESCRIPTION
The `Vec<u8>` type is often used to represent strings so the changes in https://github.com/paritytech/contracts-ui/pull/451 make the UI unusable in many cases.
Will need to adapt the input to accept strings.