### PR TITLE
feat: list testnet faucets

### DIFF
--- a/faucets.md
+++ b/faucets.md
@@ -1,0 +1,29 @@
+# Testnet Token Faucets
+
+Rococo:
+
+- https://app.element.io/#/room/#rococo-faucet:matrix.org
+
+Aleph Zero Testnet:
+
+- https://faucet.test.azero.dev/
+
+Shibuya:
+
+- https://docs.astar.network/docs/build/environment/faucet/
+
+- https://faucet.triangleplatform.com/astar/shibuya
+
+- https://www.as-faucet.xyz/en
+
+Pendulum Testnet:
+
+-
+
+Phala PoC 5:
+
+- https://wiki.phala.network/en-us/build/getting-started/deploy-contract/#claim-test-tokens
+
+T3RN t0rn:
+
+- https://faucet.t0rn.io/


### PR DESCRIPTION
Closes #460


Just added a `md` listing the faucets I was able to find for the current added testnet.

Not very visible in the ui as of yet. How about we add it to the right side?

<img width="1289" alt="Screenshot 2023-04-17 at 11 16 41" src="https://user-images.githubusercontent.com/839848/232441285-125a6204-36fa-41aa-b8db-94106ff66a80.png">

