### PR TITLE
fix: add colors for the light theme

### DIFF
--- a/src/ui/components/message/MessageSignature.tsx
+++ b/src/ui/components/message/MessageSignature.tsx
@@ -21,7 +21,13 @@ export function MessageSignature({
 }: Props) {
   return (
     <div className={classes('font-mono', isConstructor && 'constructor', className)}>
-      <span className={isConstructor ? 'dark:text-blue-400' : 'dark:text-yellow-400'}>
+      <span
+        className={
+          isConstructor
+            ? 'text-purple-700 dark:text-blue-400'
+            : 'text-yellow-700 dark:text-yellow-400'
+        }
+      >
         {method}
       </span>
       (


### PR DESCRIPTION
this PR solved issue #487 

![image](https://github.com/paritytech/contracts-ui/assets/944960/ac011506-d1cd-4449-ae26-0a0c1ee4c91c)

I think these colors work well in a light theme.