### PR TITLE
fix: execute dry run after a call

### DIFF
--- a/src/ui/components/contract/Interact.tsx
+++ b/src/ui/components/contract/Interact.tsx
@@ -111,7 +111,7 @@ export const InteractTab = ({
     }
 
     debouncedDryRun();
-  }, [api.call.contractsApi, message, params]);
+  }, [api.call.contractsApi, message, params, nextResultId]);
 
   useEffect(() => {
     async function processTx() {


### PR DESCRIPTION
This PR solved the issue #445 and execute a dry-run after a contract call
