### PR TITLE
feat: use `<InputBytes/>` for `[u8, n]` type

### DIFF
--- a/src/ui/components/form/InputBytes.tsx
+++ b/src/ui/components/form/InputBytes.tsx
@@ -3,55 +3,70 @@
 
 import { hexToU8a } from '@polkadot/util';
 import React, { useCallback, useMemo, useState } from 'react';
-import { InputHex } from './InputHex';
+import { Input } from './Input';
+import { classes } from 'helpers';
 import { ArgComponentProps } from 'types';
 
 type Props = ArgComponentProps<Uint8Array> & { length?: number };
 type Validation = { isValid: boolean; message?: string };
 
+const isHexRegex = /^0x[A-F0-9]+$/i;
 const validateFn =
   (length = 64) =>
   (value: string): Validation => {
-    if (value.length < length) {
+    if (!isHexRegex.test(value)) {
+      return { isValid: false, message: 'Not a valid hex string' };
+    }
+
+    const expectedLength = length + 2; // +2 for 0x prefix
+    if (value.length < expectedLength) {
       return { isValid: false, message: `Input too short! Expecting ${length} characters.` };
     }
-    if (value.length > length) {
+    if (value.length > expectedLength) {
       return { isValid: false, message: `Input too long! Expecting ${length} characters.` };
     }
+
     return {
       isValid: true,
       message: '',
     };
   };
 
-export function InputBytes({
-  onChange,
-  className,
-  defaultValue,
-  length,
-}: Props): React.ReactElement<Props> {
+export function InputBytes({ onChange, className, length }: Props): React.ReactElement<Props> {
+  const [value, setValue] = useState('');
   const [{ isValid, message }, setValidation] = useState<Validation>({ isValid: true });
   const validate = useMemo(() => validateFn(length), [length]);
 
   const handleChange = useCallback(
     (d: string) => {
+      setValue(d);
       const validation = validate(d);
       setValidation(validation);
-      try {
-        onChange(hexToU8a(`0x${d}`));
-      } catch (e) {
-        console.error(e);
+      if (validation.isValid) {
+        try {
+          onChange(hexToU8a(d));
+        } catch (e) {
+          console.error(e);
+        }
+      } else {
+        // TODO shouldn't this unset the value in error and invalid case to prevent form submission?
       }
     },
     [onChange, validate]
   );
 
   return (
-    <InputHex
-      className={className}
-      defaultValue={defaultValue?.toString()}
-      error={!isValid ? message : undefined}
-      onChange={handleChange}
-    />
+    <>
+      <div className="relative flex w-full items-center">
+        <Input
+          className={classes('flex-1', className)}
+          onChange={handleChange}
+          placeholder="0x0000000000000000000000000000000000000000"
+          type="text"
+          value={value}
+        />
+      </div>
+      {!isValid && <div className="mt-1 basis-full text-xs text-red-600">{message}</div>}
+    </>
   );
 }

--- a/src/ui/components/form/findComponent.tsx
+++ b/src/ui/components/form/findComponent.tsx
@@ -14,7 +14,9 @@ import { SubForm } from './SubForm';
 import { Tuple } from './Tuple';
 import { InputBn } from './InputBn';
 import { InputHash } from './InputHash';
-import { ArgComponentProps, Registry, TypeDef, TypeDefInfo } from 'types';
+import { ArgComponentProps, Hash, Registry, TypeDef, TypeDefInfo } from 'types';
+import { InputHex } from './InputHex';
+import { InputBytes } from './InputBytes';
 
 function subComponents(
   registry: Registry,
@@ -102,6 +104,18 @@ export function findComponent(
   }
 
   if (type.info === TypeDefInfo.VecFixed) {
+    if (type.sub && !Array.isArray(type.sub)) {
+      switch (type.sub.type) {
+        case 'u8':
+          return (props: ArgComponentProps<Uint8Array>) => {
+            if (!type.length) throw new Error('Fixed Vector has no length');
+            return <InputBytes {...props} length={type.length * 2} />; // 2 hex chars per byte
+          };
+        default:
+          break;
+      }
+    }
+
     const [component] = subComponents(registry, type, nestingNumber + 1);
 
     return (props: React.PropsWithChildren<ArgComponentProps<unknown[]>>) => (

--- a/src/ui/components/form/findComponent.tsx
+++ b/src/ui/components/form/findComponent.tsx
@@ -2,21 +2,20 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { AddressSelect } from '../account/Select';
-import { Input } from './Input';
-import { InputBalance } from './InputBalance';
-import { Vector } from './Vector';
 import { Bool } from './Bool';
 import { Enum } from './Enum';
+import { Input } from './Input';
+import { InputBalance } from './InputBalance';
+import { InputBn } from './InputBn';
+import { InputBytes } from './InputBytes';
+import { InputHash } from './InputHash';
 import { Option } from './Option';
-import { VectorFixed } from './VectorFixed';
 import { Struct } from './Struct';
 import { SubForm } from './SubForm';
 import { Tuple } from './Tuple';
-import { InputBn } from './InputBn';
-import { InputHash } from './InputHash';
-import { ArgComponentProps, Hash, Registry, TypeDef, TypeDefInfo } from 'types';
-import { InputHex } from './InputHex';
-import { InputBytes } from './InputBytes';
+import { Vector } from './Vector';
+import { VectorFixed } from './VectorFixed';
+import { ArgComponentProps, Registry, TypeDef, TypeDefInfo } from 'types';
 
 function subComponents(
   registry: Registry,


### PR DESCRIPTION
makes use of `<InputBytes/>` for `VecFixed` with Sub u8, which is usually easier to input encoded has hex. Closes #416.

Using the plain `Input` component to recreate some behavior of the InputHex one. However doing the checking hex step in the `validation` function. Therefore allowing not hex characters, but allows for empty value and less hassle of pasting a copied hex string to this input field.

Tested with `String`, `Hash` and `Vec<u8>` types if there is some overlap regarding input rendering. These inputs are not touched by this PR.

https://github.com/paritytech/contracts-ui/assets/839848/4e715f5e-0411-411c-90d6-fd4cbfbfca24

Contract `input-types`:

https://filebin.net/41e8q8cyl9yvf1g9
