### PR TITLE
feat: Patron integration

### DIFF
--- a/src/ui/components/form/InputFile.tsx
+++ b/src/ui/components/form/InputFile.tsx
@@ -3,13 +3,12 @@
 // Copyright 2017-2021 @polkadot/react-components authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import { Buffer } from 'buffer';
 import { createRef, useCallback, useEffect, useState } from 'react';
 import Dropzone, { DropzoneRef } from 'react-dropzone';
 import { XIcon } from '@heroicons/react/solid';
 import { DocumentTextIcon } from '@heroicons/react/outline';
 import type { FileState, InputFileProps as Props, OrFalsy } from 'types';
-import { getPatronMetadata } from 'ui/components/metadata/GetPatronMetadata';
+import { onDropPatronFile } from 'ui/components/metadata/GetPatronMetadata';
 
 const NOOP = (): void => undefined;
 
@@ -65,32 +64,8 @@ export function InputFile({
   useEffect((): void => {
     const params = new URL(window.location.href).searchParams;
     const patronCodeHash = params.get('patron');
-
     if (patronCodeHash && file?.name !== 'patron-contract.json') {
-      const metadataPromise = getPatronMetadata('metadata', patronCodeHash);
-      const wasmPromise = getPatronMetadata('wasm', patronCodeHash);
-      metadataPromise
-        .then(metadataResponse => {
-          wasmPromise
-            .then((wasmResponse: ArrayBuffer) => {
-              const result = Buffer.from(wasmResponse).toString('hex');
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-              metadataResponse.source.wasm = '0x' + result;
-              const metadataString = JSON.stringify(metadataResponse);
-              const blob = new Blob([metadataString], { type: 'application/json' });
-              const patronFile = new File([blob], 'patron-contract.json', {
-                lastModified: new Date(0).getTime(),
-                type: 'json',
-              });
-              onDrop([patronFile]);
-            })
-            .catch(e => {
-              console.error(e);
-            });
-        })
-        .catch(e => {
-          console.error(e);
-        });
+      onDropPatronFile(patronCodeHash, onDrop);
     }
 
     if (file !== propsFile) {

--- a/src/ui/components/metadata/GetPatronMetadata.ts
+++ b/src/ui/components/metadata/GetPatronMetadata.ts
@@ -1,4 +1,7 @@
-export function getPatronMetadata(field: string, hash: string) {
+// Copyright 2023 @paritytech/contracts-ui authors & contributors
+import { Buffer } from 'buffer';
+
+function getPatronMetadata(field: string, hash: string) {
   const options = {
     method: 'GET',
     headers:
@@ -20,4 +23,25 @@ export function getPatronMetadata(field: string, hash: string) {
       return field === 'metadata' ? response.json() : response.arrayBuffer();
     },
   );
+}
+
+export function onDropPatronFile(patronCodeHash: string, onDrop: (files: File[]) => void) {
+  const metadataPromise = getPatronMetadata('metadata', patronCodeHash);
+  const wasmPromise = getPatronMetadata('wasm', patronCodeHash);
+  Promise.all([metadataPromise, wasmPromise])
+    .then(([metadataResponse, wasmResponse]) => {
+      const result = Buffer.from(wasmResponse as ArrayBuffer).toString('hex');
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      metadataResponse.source.wasm = '0x' + result;
+      const metadataString = JSON.stringify(metadataResponse);
+      const blob = new Blob([metadataString], { type: 'application/json' });
+      const patronFile = new File([blob], 'patron-contract.json', {
+        lastModified: new Date(0).getTime(),
+        type: 'json',
+      });
+      onDrop([patronFile]);
+    })
+    .catch(e => {
+      console.error(e);
+    });
 }

--- a/src/ui/components/metadata/GetPatronMetadata.ts
+++ b/src/ui/components/metadata/GetPatronMetadata.ts
@@ -1,0 +1,23 @@
+export function getPatronMetadata(field: string, hash: string) {
+  const options = {
+    method: 'GET',
+    headers:
+      field === 'metadata'
+        ? {
+            'Content-Type': 'application/json',
+          }
+        : {
+            'Content-Type': 'text/plain; charset=UTF-8',
+          },
+    mode: 'cors' as RequestMode,
+  };
+
+  return fetch('https://api.patron.works/buildSessions/' + field + '/' + hash, options).then(
+    response => {
+      if (!response.ok) {
+        throw new Error(`HTTP error! Status: ${response.status}`);
+      }
+      return field === 'metadata' ? response.json() : response.arrayBuffer();
+    },
+  );
+}


### PR DESCRIPTION
Hi Parity Technologies team!
As we said before, [Brushfam](https://brushfam.io/) team wants to add a URL parameter to automatically set `bundle.contract` file to the`/instantiate` route on your App. So that we can integrate our [Patron](https://github.com/Brushfam/patron-backend) product with countracts-ui and fetch our metadata.

I've added file-creating logic to `InputFile.tsx` and that will affect only the case when a link contains Patron parameter, so it won't change anything for the default flow of your App. Also, I added `eslint-disable-next-line` on the 77 line, because `metadataResponse` is always a JSON type, and for this type, we can add a new field using dot syntax.

Thank you for your communication and for any feedback =)