### PR TITLE
feat: links to `use.ink` and `ink-examples`

### DIFF
--- a/src/ui/components/homepage/HelpBox.tsx
+++ b/src/ui/components/homepage/HelpBox.tsx
@@ -1,22 +1,30 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { Button } from '../common/Button';
-
 export function HelpBox(): React.ReactElement | null {
   return (
-    <div className="mb-8 border-b border-gray-200 pb-8 dark:border-gray-800">
-      <div className="relative w-auto rounded border border-gray-200 p-4 dark:border-gray-800 dark:bg-elevation-1">
-        <div className="pb-1 text-sm font-semibold text-blue-500">Tell us more about yourself</div>
-        <div className="pb-2 text-xs text-gray-500 dark:text-gray-400">
-          We would love to know more about you so we can make our products better.
-        </div>
+    <div className="mb-8 border-b pb-8 border-gray-200  dark:border-gray-800">
+      <div className="relative flex gap-2 flex-col w-auto rounded border border-gray-200 p-4 dark:border-gray-800 dark:bg-elevation-1">
         <div>
-          <a href="https://forms.gle/hif9sHBr3bYPZjt38" rel="noreferrer" target="_blank">
-            <Button className="border-2 px-3 py-1.5" variant="default">
-              Take quick survey
-            </Button>
-          </a>
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            New to ink!? Check out the documentation!
+          </div>
+          <div className="text-sm font-semibold text-blue-500">
+            <a href="https://use.ink/" target="_blank" rel="noreferrer">
+              use.ink
+            </a>
+          </div>
+        </div>
+
+        <div>
+          <div className="text-xs text-gray-500 dark:text-gray-400">
+            Need some guidance? Find an example!
+          </div>
+          <div className="text-sm font-semibold text-blue-500">
+            <a href="https://github.com/paritytech/ink-examples" target="_blank" rel="noreferrer">
+              github.com/paritytech/ink-examples
+            </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes #411.

### Before:

![Screenshot 2023-11-16 at 17 48 51](https://github.com/paritytech/contracts-ui/assets/839848/2dd13a7d-27b4-4925-84dd-382746df4aee)


### After
![Screenshot 2023-11-16 at 16 48 34](https://github.com/paritytech/contracts-ui/assets/839848/18e618c3-cd8b-410d-85f9-0f8be6012c3c)
