### PR TITLE
fix: prevents turning falsy values into `null`

### DIFF
--- a/src/lib/callOptions.ts
+++ b/src/lib/callOptions.ts
@@ -65,7 +65,7 @@ export function transformUserInput(
       return registry.createType('Balance', value);
     }
 
-    return value || null;
+    return value;
   });
 }
 const encoder = new TextEncoder();


### PR DESCRIPTION
Resolves #517.

This function turned every js falsy value, like `false`, `""`, `0` into `null`, thereby preventing passing these actual values as inputs to contract calls.

https://github.com/paritytech/contracts-ui/blob/2387223e1c9d5b0430831141862afea0e834382b/src/lib/callOptions.ts#L56-L70

