### PR TITLE
fix: #513 sign with injected wallets on local node

### DIFF
--- a/src/ui/contexts/TransactionsContext.tsx
+++ b/src/ui/contexts/TransactionsContext.tsx
@@ -17,7 +17,7 @@ export const TransactionsContext = createContext({} as unknown as TransactionsSt
 export function TransactionsContextProvider({
   children,
 }: React.PropsWithChildren<Partial<TransactionsState>>) {
-  const { api, systemChainType } = useApi();
+  const { api } = useApi();
   const [txs, setTxs] = useState<TransactionsQueue>({});
 
   function queue(options: TxOptions): number {


### PR DESCRIPTION
Resolves #513/#520 by referring to the selected account if it's a testing account or not and acting accordingly.

This is the actual change:
https://github.com/paritytech/contracts-ui/pull/527/files#diff-d22473d5f78c6d4516163586c619fa5d61e960611e085cd39c676ab0afe72e81R41-R53

The rest just got reformatted due to a now shorter line: 
https://github.com/paritytech/contracts-ui/pull/527/files#diff-d22473d5f78c6d4516163586c619fa5d61e960611e085cd39c676ab0afe72e81R56-R93