### PR TITLE
chore: ui polish 💅 

### DIFF
--- a/src/ui/components/contract/DryRunResult.tsx
+++ b/src/ui/components/contract/DryRunResult.tsx
@@ -77,8 +77,8 @@ export function DryRunResult({
         {isDispatchable && (
           <div data-cy="dry-run-estimations">
             <span>GasConsumed</span>
-            <div className="flex">
-              <div className="basis-1/2 pr-2">
+            <div className="flex flex-row gap-4">
+              <div className="flex-1">
                 <OutcomeItem
                   displayValue={`refTime: ${gasConsumed.refTime.toString()}`}
                   id={`gcr-${message.method}`}
@@ -86,7 +86,7 @@ export function DryRunResult({
                   title=""
                 />
               </div>
-              <div className="basis-1/2 pl-2">
+              <div className="flex-1">
                 <OutcomeItem
                   displayValue={`proofSize: ${gasConsumed.proofSize.toString()}`}
                   id={`gcp-${message.method}`}

--- a/src/ui/components/instantiate/Step3.tsx
+++ b/src/ui/components/instantiate/Step3.tsx
@@ -1,16 +1,15 @@
 // Copyright 2022 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { useParams } from 'react-router';
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router';
 import { Account } from '../account/Account';
 import { Button, Buttons } from '../common/Button';
-import { useApi, useInstantiate, useTransactions } from 'ui/contexts';
-import { truncate } from 'lib/util';
-import { SubmittableResult } from 'types';
-import { useNewContract } from 'ui/hooks';
-import { createInstantiateTx } from 'services/chain';
 import { printBN } from 'lib/bn';
+import { createInstantiateTx } from 'services/chain';
+import { SubmittableResult } from 'types';
+import { useApi, useInstantiate, useTransactions } from 'ui/contexts';
+import { useNewContract } from 'ui/hooks';
 
 export function Step3() {
   const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
@@ -21,7 +20,7 @@ export function Step3() {
   const [txId, setTxId] = useState<number>(0);
   const onSuccess = useNewContract();
 
-  const displayHash = codeHashUrlParam || metadata?.info.source.wasmHash.toHex();
+  const codeHash = codeHashUrlParam || metadata?.info.source.wasmHash.toHex();
 
   useEffect(() => {
     const isValid = (result: SubmittableResult) => !result.isError && !result.dispatchError;
@@ -54,42 +53,48 @@ export function Step3() {
     <>
       <div className="review">
         <div className="field full">
-          <p className="key">Account</p>
+          <p className="key">Deployer</p>
           <div className="value">
             <Account value={accountId} />
           </div>
         </div>
 
         <div className="field full">
-          <p className="key">Name</p>
+          <p className="key">Contract Name</p>
           <p className="value">{name}</p>
         </div>
         {metadata?.constructors[constructorIndex].isPayable && value && (
-          <div className="field">
+          <div className="field full">
             <p className="key">Value</p>
             <p className="value">{printBN(value)}</p>
           </div>
         )}
 
-        <div className="field">
+        <div className="field full">
           <p className="key">Weight</p>
           <p className="value">{gasLimit && printBN(gasLimit.refTime.toBn())}</p>
         </div>
 
-        {displayHash && (
-          <div className="field">
+        {codeHash && (
+          <div className="field full">
             <p className="key">Code Hash</p>
-            <p className="value">{truncate(displayHash)}</p>
+            <p className="value">{codeHash}</p>
           </div>
         )}
 
         {txs[txId]?.extrinsic.args[3] && (
-          <div className="field">
+          <div className="field full">
             <p className="key">Data</p>
-            <p className="value">{truncate(txs[txId]?.extrinsic.args[3].toHex())}</p>
+            <textarea
+              className="w-full bg-transparent text-sm value"
+              readOnly
+              rows={4}
+              value={txs[txId]?.extrinsic.args[3].toHex()}
+            />
           </div>
         )}
       </div>
+
       <Buttons>
         <Button
           isDisabled={txs[txId]?.status === 'processing'}

--- a/src/ui/components/instantiate/Wizard.tsx
+++ b/src/ui/components/instantiate/Wizard.tsx
@@ -14,8 +14,8 @@ export function Wizard() {
   } = useInstantiate();
 
   return (
-    <div className="m-1 flex w-full">
-      <main className="xs:w-full p-4 md:mr-2 md:flex-1">
+    <div className="flex w-full gap-4">
+      <main className="xs:w-full md:flex-1">
         <Step1 />
         {metadata && <Step2 />}
         {step === 3 && <Step3 />}

--- a/src/ui/pages/Instantiate.tsx
+++ b/src/ui/pages/Instantiate.tsx
@@ -2,47 +2,41 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { Link, useParams } from 'react-router-dom';
-import { InstantiateContextProvider } from 'ui/contexts';
+import { RootLayout } from '../layout/RootLayout';
 import { Wizard } from 'ui/components/instantiate';
+import { InstantiateContextProvider } from 'ui/contexts';
 
 export function Instantiate() {
   const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
 
   return (
-    <div className="m-2 w-full overflow-y-auto overflow-x-hidden px-5 py-3">
-      <div className="grid gap-5 md:grid-cols-12">
-        <div className="p-4 md:col-span-9">
-          <div className="space-y-1 border-b border-gray-200 pb-6 dark:border-gray-800">
-            <h1>
-              {codeHashUrlParam
-                ? 'Instantiate Contract from Code Hash'
-                : 'Upload and Instantiate Contract'}
-            </h1>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
-              {codeHashUrlParam ? (
-                <>
-                  You can upload and instantiate new contract code{' '}
-                  <Link className="text-blue-500" to="/instantiate">
-                    here
-                  </Link>
-                  .
-                </>
-              ) : (
-                <>
-                  You can instantiate a new contract from an existing code bundle{' '}
-                  <Link className="text-blue-500" to="/hash-lookup">
-                    here
-                  </Link>
-                  .
-                </>
-              )}
-            </p>
-          </div>
-        </div>
-      </div>
+    <RootLayout
+      heading={
+        codeHashUrlParam ? 'Instantiate Contract from Code Hash' : 'Upload and Instantiate Contract'
+      }
+      help={
+        codeHashUrlParam ? (
+          <>
+            You can upload and instantiate new contract code{' '}
+            <Link className="text-blue-500" to="/instantiate">
+              here
+            </Link>
+            .
+          </>
+        ) : (
+          <>
+            You can instantiate a new contract from an existing code bundle{' '}
+            <Link className="text-blue-500" to="/hash-lookup">
+              here
+            </Link>
+            .
+          </>
+        )
+      }
+    >
       <InstantiateContextProvider>
         <Wizard />
       </InstantiateContextProvider>
-    </div>
+    </RootLayout>
   );
 }


### PR DESCRIPTION
## Use `RootLayout` for `/instantiate`

Before we did not use the `RootLayout` on the `/instatiate` route, which caused the page to jump on navigation.

### Before

https://github.com/paritytech/contracts-ui/assets/839848/44aec7ce-1f78-4e94-bef5-a01d80383e30

## Instantiation Review

Before we used a lot of space and showed truncated values for code hash and extrinsic data. This truncated data was lossy, the user was not able to copy the whole value through the truncation. 

Now it shows both values in full and each value on a dedicated row. Making it as transparent as possible what is going to happen.

### Before
<img width="550px" src="https://github.com/paritytech/contracts-ui/assets/839848/6bca62a0-03a3-49e9-8d12-06cbf62ff031"/>



### After

<img width="550px" src="https://github.com/paritytech/contracts-ui/assets/839848/f1d27cfc-5567-40bc-b2ee-90c1b7b017b8"/>


## Dry Run Results

Uses newer css `gap` feature instead of multiple usages of `mb`/`margin-bottom` on individual elements.

### Before

<img width="480px" src="https://github.com/paritytech/contracts-ui/assets/839848/dd043c1a-87b0-4f35-be51-cd5aa8b170cc"/>

### After

<img width="480px" src="https://github.com/paritytech/contracts-ui/assets/839848/95d5a057-0d2f-42f1-ba92-889e5747f01d"/>
