### PR TITLE
chore: only runs CI on pull requests & `master`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: 'Build project'
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   install:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,6 +1,10 @@
 name: 'E2E tests'
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   contracts-node-binary:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,6 +1,10 @@
 name: 'Unit Tests'
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   vitest-tests:

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -1,6 +1,8 @@
 name: 'Validate PR title'
 
 on:
+  pull_request:
+    branches: [master]
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
Before we run some workflows for every branch even if no PR was created. As the checks are not yet relevant, we can save on the CI minutes by running them only on PRs and `master` pushes.