### PR TITLE
feat: reuse known metadata when adding already deployed contracts

### DIFF
--- a/src/ui/hooks/useStoredMetadata.tsx
+++ b/src/ui/hooks/useStoredMetadata.tsx
@@ -1,0 +1,23 @@
+// Copyright 2022-2024 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { useDbQuery } from '.';
+import { Abi } from 'types';
+import { useDatabase } from 'ui/contexts';
+
+export const useStoredMetadata = () => {
+  const { db } = useDatabase();
+
+  return useDbQuery(async () => {
+    const collectedAbis = new Set();
+    const storedAbis: Abi[] = [];
+    await db.contracts.each(contract => {
+      if (collectedAbis.has(contract.codeHash)) return;
+
+      const abi = new Abi(contract.abi);
+      storedAbis.push(abi);
+      collectedAbis.add(contract.codeHash);
+    });
+    return storedAbis;
+  }, [db]);
+};

--- a/src/ui/pages/AddressLookup.tsx
+++ b/src/ui/pages/AddressLookup.tsx
@@ -1,23 +1,26 @@
 // Copyright 2022-2024 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
+import { CheckCircleIcon } from '@heroicons/react/outline';
+import { Abi } from '@polkadot/api-contract';
 import { useEffect, useState } from 'react';
-import { CheckCircleIcon, XCircleIcon } from '@heroicons/react/outline';
 import { useNavigate } from 'react-router-dom';
 import { classes, isValidAddress } from 'lib/util';
+import { getContractInfo } from 'services/chain';
 import {
   Button,
   Buttons,
+  Dropdown,
   FormField,
-  getValidation,
   Input,
   InputFile,
+  getValidation,
   useMetadataField,
 } from 'ui/components';
-import { RootLayout } from 'ui/layout';
 import { useApi, useDatabase } from 'ui/contexts';
 import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
-import { getContractInfo } from 'services/chain';
+import { useStoredMetadata } from 'ui/hooks/useStoredMetadata';
+import { RootLayout } from 'ui/layout';
 
 export function AddressLookup() {
   const [searchString, setSearchString] = useState('');
@@ -27,7 +30,7 @@ export function AddressLookup() {
 
   const {
     file,
-    value: metadata,
+    value: fileMetadata,
     isLoading,
     isStored,
     onChange,
@@ -38,6 +41,19 @@ export function AddressLookup() {
   const { value: name, onChange: setName, ...nameValidation } = useNonEmptyString('New Contract');
 
   const { db } = useDatabase();
+  const [abis, isLoadingStoredAbis] = useStoredMetadata();
+  const [knownMetadata, selectKnownMetadata] = useState<Abi | undefined>(undefined);
+  const [metadata, setMetadata] = useState<Abi | undefined>(undefined);
+
+  useEffect(() => {
+    if (fileMetadata) {
+      setMetadata(fileMetadata);
+    } else if (knownMetadata) {
+      setMetadata(knownMetadata);
+    } else {
+      setMetadata(undefined);
+    }
+  }, [fileMetadata, knownMetadata]);
 
   useEffect((): void => {
     async function validate() {
@@ -46,7 +62,18 @@ export function AddressLookup() {
           const isOnChain = await getContractInfo(api, searchString);
           if (isOnChain) {
             const contract = await db.contracts.get({ address: searchString });
-            contract ? navigate(`/contract/${searchString}`) : setAddress(searchString);
+            // Contract is already instantiated in current UI
+            if (contract) {
+              navigate(`/contract/${searchString}`);
+            } else {
+              if (abis) {
+                const knownAbi = abis.find(
+                  a => a.info.source.wasmHash.toHex() === isOnChain.codeHash.toHex(),
+                );
+                selectKnownMetadata(knownAbi);
+              }
+              setAddress(searchString);
+            }
           } else {
             setAddress('');
           }
@@ -56,7 +83,8 @@ export function AddressLookup() {
       }
     }
     validate().catch(e => console.error(e));
-  }, [api, address, searchString, db.contracts, navigate]);
+  }, [api, address, searchString, db.contracts, navigate, abis]);
+
   return (
     <RootLayout
       heading="Add contract from address"
@@ -64,47 +92,72 @@ export function AddressLookup() {
     >
       <FormField
         className="relative"
-        help="The address of the contract you want to interact with"
+        help="The address of the contract you want to interact with."
         id="address"
         isError={!!searchString && !address}
         label="Contract Address"
         message={isValidAddress(searchString) ? 'Address is not on-chain ' : 'Address is not valid'}
       >
-        {' '}
         <Input
           className={classes('relative mb-4 flex items-center')}
           onChange={setSearchString}
           placeholder="Paste an on-chain contract address"
           value={searchString}
         >
-          {address ? (
+          {address && (
             <div className="absolute right-2 flex items-center text-green-500">
               <span className="w-22 mr-1 text-xs">on-chain</span>
               <CheckCircleIcon aria-hidden="true" className="h-4 w-4" />
             </div>
-          ) : (
-            searchString && (
-              <XCircleIcon aria-hidden="true" className="-ml-8 h-5 w-5 text-red-500" />
-            )
           )}
         </Input>
       </FormField>
 
-      {address && (
-        <>
+      <>
+        <FormField
+          help="A name for the new contract to help users distinguish it. Only used for display purposes."
+          id="name"
+          label="Contract Name"
+          {...nameValidation}
+        >
+          <Input
+            id="contractName"
+            onChange={setName}
+            placeholder="Give your contract a descriptive name"
+            value={name}
+          />
+        </FormField>
+
+        {knownMetadata ? (
           <FormField
-            help="A name for the new contract to help users distinguish it. Only used for display purposes."
-            id="name"
-            label="Contract Name"
-            {...nameValidation}
+            help={'Reuse metadata you used before.'}
+            id="known_metadata"
+            label={'Known Metadata'}
           >
-            <Input
-              id="contractName"
-              onChange={setName}
-              placeholder="Give your contract a descriptive name"
-              value={name}
-            />
+            {!isLoadingStoredAbis && abis && abis.length > 0 && (
+              <Dropdown
+                className="mb-4"
+                id="known_metadata"
+                onChange={(abi: Abi | undefined) => {
+                  selectKnownMetadata(abi);
+                }}
+                options={abis.map(abi => ({
+                  label: `${abi.info.contract.name} - ${abi.info.source.wasmHash.toHex()}`,
+                  value: abi,
+                }))}
+                value={knownMetadata}
+              >
+                No Metadata found
+              </Dropdown>
+            )}
+            <p
+              className="mt-[-10px] cursor-pointer pl-1 text-sm text-green-500 underline hover:text-green-600"
+              onClick={() => selectKnownMetadata(undefined)}
+            >
+              × Use new metadata instead
+            </p>
           </FormField>
+        ) : (
           <FormField
             help={
               'The contract metadata JSON file to use in order to interact with this contract. Constructor and message information will be derived from this file.'
@@ -121,30 +174,36 @@ export function AddressLookup() {
               value={file}
             />
           </FormField>
-          <Buttons>
-            <Button
-              data-cy="next-btn"
-              isDisabled={!metadata || !nameValidation.isValid || !metadataValidation.isValid}
-              onClick={async () => {
-                if (!metadata) return;
-                const document = {
-                  abi: metadata.json,
-                  address,
-                  codeHash: metadata.info.source.wasmHash.toHex(),
-                  date: new Date().toISOString(),
-                  name,
-                  external: true,
-                };
-                await db.contracts.add(document);
-                navigate(`/contract/${address}`);
-              }}
-              variant="primary"
-            >
-              Add contract
-            </Button>
-          </Buttons>
-        </>
-      )}
+        )}
+
+        <Buttons>
+          <Button
+            data-cy="next-btn"
+            isDisabled={
+              !metadata ||
+              !nameValidation.isValid ||
+              (!!fileMetadata && !metadataValidation.isValid) ||
+              !address
+            }
+            onClick={async () => {
+              if (!metadata) return;
+              const document = {
+                abi: metadata.json,
+                address,
+                codeHash: metadata.info.source.wasmHash.toHex(),
+                date: new Date().toISOString(),
+                name,
+                external: true,
+              };
+              await db.contracts.add(document);
+              navigate(`/contract/${address}`);
+            }}
+            variant="primary"
+          >
+            Add contract
+          </Button>
+        </Buttons>
+      </>
     </RootLayout>
   );
 }

--- a/src/ui/pages/SelectCodeHash.tsx
+++ b/src/ui/pages/SelectCodeHash.tsx
@@ -11,7 +11,7 @@ export function SelectCodeHash() {
       heading="Instantiate Contract from Code Hash"
       help={
         <>
-          You can upload and instantate new contract code{' '}
+          You can upload and instantiate new contract code{' '}
           <Link className="text-blue-500" to="/instantiate">
             here
           </Link>


### PR DESCRIPTION
Closes #464

The Dropdown allows to choose any metadata the frontend already knows about. However it's only visible and preselects the metadata which matches with the codeHash with the onchain contract. 

I'm not sure if we should allow for this. Could a metadata be valid and usable if the codeHash is not the same? Afaik the metadata is compatible with any contract as long as the messages and events are the same, right?

https://github.com/paritytech/contracts-ui/assets/839848/205c930e-e780-4771-97f4-0a7ab30f8008

