### PR TITLE
chore: upgrades GitHub Actions which where using outdated node versions

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Download node artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: substrate-contracts-node
         path: ./

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: 'UI Tests - Chrome'
-        uses: cypress-io/github-action@v5.0.5
+        uses: cypress-io/github-action@v6
         with:
           start: yarn start
           wait-on: 'http://localhost:8081'
@@ -75,7 +75,7 @@ jobs:
         uses: ./.github/actions/prepare
 
       - name: 'UI Tests - Firefox'
-        uses: cypress-io/github-action@v5.0.5
+        uses: cypress-io/github-action@v6
         with:
           start: yarn start
           wait-on: 'http://localhost:8081'

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -14,7 +14,7 @@ jobs:
           curl -L "https://github.com/paritytech/substrate-contracts-node/releases/latest/download/substrate-contracts-node-linux.tar.gz" -O
           ls -lash
       - name: Save node artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: substrate-contracts-node
           if-no-files-found: error

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare test environment
         uses: ./.github/actions/prepare
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Prepare test environment
         uses: ./.github/actions/prepare

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
The following used GitHub actions used node 16, a no longer maintained version. No applicable breaking changes where introduced in the next versions.

+ actions/download-artifact@v3
+ actions/upload-artifact@v3
+ actions/checkout@3
+ cypress-io/github-action@v5.0.5

![Screenshot 2024-03-04 at 15 19 21](https://github.com/paritytech/contracts-ui/assets/839848/00a91536-cced-48fe-a9fb-bc14c607f102)
