### PR TITLE
fix: requires selected account for interaction to be available

### DIFF
--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -92,12 +92,12 @@ export function Step1() {
           help="The account to use for this instantiation. The fees and storage deposit will be deducted from this account."
           id="accountId"
           label="Account"
+          isError={isAccountAvailable === false}
+          message="Selected Account is not available to sign extrinsics."
         >
           <AccountSelect
             className="mb-2"
             id="accountId"
-            isError={isAccountAvailable === false}
-            message="Selected Account is not available to sign extrinsics."
             onChange={setAccountId}
             value={accountId}
           />

--- a/src/ui/components/instantiate/Step1.tsx
+++ b/src/ui/components/instantiate/Step1.tsx
@@ -3,19 +3,20 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router';
-import { Button, Buttons } from '../common/Button';
-import { Input, InputFile, Form, FormField, useMetadataField, getValidation } from '../form';
-import { Loader } from '../common/Loader';
 import { AccountSelect } from '../account';
+import { Button, Buttons } from '../common/Button';
+import { Loader } from '../common/Loader';
+import { Form, FormField, Input, InputFile, getValidation, useMetadataField } from '../form';
 import { MessageDocs } from '../message';
 import { Metadata } from '../metadata';
 import { CodeHash } from './CodeHash';
-import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
 import { useApi, useDatabase, useInstantiate } from 'ui/contexts';
 import { useDbQuery } from 'ui/hooks';
+import { useNonEmptyString } from 'ui/hooks/useNonEmptyString';
 
 import { fileToFileState } from 'lib/fileToFileState';
 import { getContractFromPatron } from 'lib/getContractFromPatron';
+import { useAccountAvailable } from 'ui/hooks/useAccountAvailable';
 
 export function Step1() {
   const { codeHash: codeHashUrlParam } = useParams<{ codeHash: string }>();
@@ -29,6 +30,7 @@ export function Step1() {
   const { setStep, setData, data, step } = useInstantiate();
 
   const [accountId, setAccountId] = useState('');
+  const isAccountAvailable = useAccountAvailable(accountId);
   const { value: name, onChange: setName, ...nameValidation } = useNonEmptyString();
 
   const {
@@ -94,6 +96,8 @@ export function Step1() {
           <AccountSelect
             className="mb-2"
             id="accountId"
+            isError={isAccountAvailable === false}
+            message="Selected Account is not available to sign extrinsics."
             onChange={setAccountId}
             value={accountId}
           />
@@ -185,7 +189,12 @@ export function Step1() {
       <Buttons>
         <Button
           data-cy="next-btn"
-          isDisabled={!metadata || !nameValidation.isValid || !metadataValidation.isValid}
+          isDisabled={
+            !metadata ||
+            !nameValidation.isValid ||
+            !metadataValidation.isValid ||
+            isAccountAvailable === false
+          }
           onClick={submitStep1}
           variant="primary"
         >

--- a/src/ui/hooks/useAccountAvailable.ts
+++ b/src/ui/hooks/useAccountAvailable.ts
@@ -4,7 +4,7 @@
 import { keyring } from '@polkadot/ui-keyring';
 import { useMemo } from 'react';
 
-export const useAccountAvailable = (accountId: string): boolean | undefined =>
+export const useAccountAvailable = (accountId?: string): boolean | undefined =>
   useMemo(() => {
     if (accountId === '' || accountId === undefined) return undefined;
     try {

--- a/src/ui/hooks/useAccountAvailable.ts
+++ b/src/ui/hooks/useAccountAvailable.ts
@@ -1,0 +1,16 @@
+// Copyright 2022-2024 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
+import { keyring } from '@polkadot/ui-keyring';
+import { useMemo } from 'react';
+
+export const useAccountAvailable = (accountId: string): boolean | undefined =>
+  useMemo(() => {
+    if (accountId === '' || accountId === undefined) return undefined;
+    try {
+      keyring.getPair(accountId);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [accountId]);


### PR DESCRIPTION
Closes #458 .

As our `AccountSelect` allows for creating new select options on the fly, the user can create new options which are not available to sign a deployment or a contract call extrinsic. I added a second layer validation of this value in the deploy and interaction of contracts. 

Disabling the creation of options on the fly is not what we want, as this component is used as a general account input. In this case we want to offer the user to select known accounts but also put it any valid account id.

The demo shows the error first on the latest deployed version of `contracts-ui` and later the behavior with the changes in this branch.

https://github.com/paritytech/contracts-ui/assets/839848/61d1c3be-8094-4996-b0bb-767f1bd968eb

