### PR TITLE
fix: removes unecessary encoding of salt during dryrun

### DIFF
--- a/src/lib/callOptions.ts
+++ b/src/lib/callOptions.ts
@@ -1,9 +1,8 @@
 // Copyright 2022-2024 @paritytech/contracts-ui authors & contributors
 // SPDX-License-Identifier: GPL-3.0-only
 
-import { randomAsU8a } from './util';
 import { BN_ZERO } from './bn';
-import { UIStorageDeposit, ContractCallOutcome, BN, WeightV2, AbiParam, Registry } from 'types';
+import { AbiParam, BN, ContractCallOutcome, Registry, UIStorageDeposit, WeightV2 } from 'types';
 
 export function decodeStorageDeposit(
   storageDeposit: ContractCallOutcome['storageDeposit'],
@@ -68,4 +67,3 @@ export function transformUserInput(
     return value;
   });
 }
-const encoder = new TextEncoder();

--- a/src/lib/callOptions.ts
+++ b/src/lib/callOptions.ts
@@ -69,8 +69,3 @@ export function transformUserInput(
   });
 }
 const encoder = new TextEncoder();
-
-export function encodeSalt(salt: Uint8Array | string = randomAsU8a()): Uint8Array {
-  if (typeof salt === 'string') return encoder.encode(salt);
-  return salt;
-}

--- a/src/ui/components/instantiate/Step2.tsx
+++ b/src/ui/components/instantiate/Step2.tsx
@@ -24,12 +24,7 @@ import {
   useBalance,
 } from 'ui/hooks';
 import { AbiMessage, Balance, OrFalsy } from 'types';
-import {
-  decodeStorageDeposit,
-  encodeSalt,
-  getGasLimit,
-  getStorageDepositLimit,
-} from 'lib/callOptions';
+import { decodeStorageDeposit, getGasLimit, getStorageDepositLimit } from 'lib/callOptions';
 import { BN_ZERO } from 'lib/bn';
 import { hasRevertFlag } from 'lib/hasRevertFlag';
 
@@ -79,7 +74,7 @@ export function Step2() {
       getStorageDepositLimit(storageDepositLimit.isActive, storageDepositLimit.value, api.registry),
       codeHashUrlParam ? { Existing: codeHashUrlParam } : { Upload: metadata?.info.source.wasm },
       inputData ?? '',
-      isUsingSalt ? encodeSalt(salt.value) : '',
+      isUsingSalt ? salt.value : '',
     ];
   }, [
     accountId,


### PR DESCRIPTION
Closes #382.

The ui was encoding the salt during dryrunning the instantiate of contracts but not during the actual instantiation. Therefore the contract address shown from the dry run result was not matching the actual deployed contract address.

Video showing the bug before and after fix:


https://github.com/paritytech/contracts-ui/assets/839848/5a5b9b7b-a0b6-4697-883f-dd46037ad913

Can be tested on the deploy preview.
