### PR TITLE
feat: Add Pop Network Testnet

### DIFF
--- a/FAUCETS.md
+++ b/FAUCETS.md
@@ -8,6 +8,10 @@ Rococo:
 
 - https://app.element.io/#/room/#rococo-faucet:matrix.org
 
+Paseo:
+
+- https://faucet.polkadot.io/paseo
+
 Aleph Zero Testnet:
 
 - https://faucet.test.azero.dev/
@@ -25,6 +29,10 @@ Shibuya:
 Phala PoC 5:
 
 - https://wiki.phala.network/en-us/build/getting-started/deploy-contract/#claim-test-tokens
+
+Pop Network:
+
+- https://onboard.popnetwork.xyz/
 
 T3RN t0rn:
 

--- a/snapshots.js
+++ b/snapshots.js
@@ -1,3 +1,6 @@
+// Copyright 2022-2024 @paritytech/contracts-ui authors & contributors
+// SPDX-License-Identifier: GPL-3.0-only
+
 module.exports = {
   __version: '12.17.2',
   'Storage Types Contract': {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -32,6 +32,12 @@ export const LOCAL = {
 //   rpc: 'wss://wss.agung.peaq.network',
 // };
 
+const POP_NETWORK_TESTNET = {
+  relay: 'Paseo',
+  name: 'Pop Network Testnet',
+  rpc: 'wss://rpc2.paseo.popnetwork.xyz',
+};
+
 const PHALA_TESTNET = {
   relay: undefined,
   name: 'Phala PoC-6',
@@ -106,6 +112,7 @@ export const TESTNETS = [
     T3RN_T0RN,
     TERNOA_ALPHANET,
     PENDULUM_TESTNET,
+    POP_NETWORK_TESTNET,
     ZEITGEIST_BATTERY_STATION,
   ].sort((a, b) => a.name.localeCompare(b.name)),
   LOCAL,

--- a/src/ui/components/contract/DryRunResult.tsx
+++ b/src/ui/components/contract/DryRunResult.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 import { AbiMessage } from '@polkadot/api-contract/types';
+import { formatProofSize, formatRefTime } from '../../../lib/formatWeight';
 import { DryRunError } from './DryRunError';
 import { OutcomeItem } from './OutcomeItem';
 import { classes } from 'lib/util';
@@ -9,7 +10,6 @@ import { ContractExecResult, Registry } from 'types';
 import { useApi } from 'ui/contexts';
 import { getDecodedOutput } from 'lib/output';
 import { decodeStorageDeposit } from 'lib/callOptions';
-import { formatProofSize, formatRefTime } from '../../../lib/formatWeight';
 
 interface Props {
   outcome: ContractExecResult;

--- a/src/ui/styles/dropdown.css
+++ b/src/ui/styles/dropdown.css
@@ -61,12 +61,12 @@
 }
 
 .dropdown.chain .dropdown__single-value {
-  @apply flex flex-grow items-center text-sm font-medium;
+  @apply flex w-full flex-grow items-center text-sm font-medium;
 }
 
 .dropdown.chain .dropdown__single-value:before {
   content: '';
-  @apply ml-1 mr-2 block h-1.5 w-1.5 rounded-full;
+  @apply mr-2 block h-1.5 w-1.5 rounded-full;
 }
 
 .dropdown.chain.isConnected .dropdown__single-value:before {


### PR DESCRIPTION
Adds Pop Network Testnet to the list of Testnets available in the drop down.
Adds a link to Paseo's faucet and Pop Network token onboarding page to FAUCETS.md 
Changes introduced to `snapshots.js` and `src/ui/components/contract/DryRunResult.tsx` after linting the code.